### PR TITLE
Fix print function

### DIFF
--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -593,14 +593,14 @@ extern ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t dim);
  * @param ofile the file to write to.
  * @param cdd   a CDD.
  */
-extern void cdd_fprintdot(FILE* ofile, ddNode* cdd);
+extern void cdd_fprintdot(FILE* ofile, ddNode* cdd, bool push_negate);
 
 /**
  * Print a CDD \a r as a dot input file to stdout.
  * @see cdd_fprintdot
  * @param cdd   a CDD.
  */
-extern void cdd_printdot(ddNode* cdd);
+extern void cdd_printdot(ddNode* cdd, bool push_negate);
 
 /**
  * Dump all the CDD nodes.
@@ -828,12 +828,12 @@ private:
     friend cdd cdd_reduce2(const cdd&);
     friend bool cdd_contains(const cdd&, raw_t* dbm, int32_t dim);
     friend cdd cdd_extract_dbm(const cdd&, raw_t* dbm, int32_t dim);
-    friend void cdd_fprintdot(FILE* ofile, const cdd&);
-    friend void cdd_printdot(const cdd&);
-    friend void cdd_fprint_code(FILE* ofile, const cdd&, cdd_print_varloc_f printer1, cdd_print_clockdiff_f printer2,
-                                void* dict);
-    friend void cdd_fprint_graph(FILE* ofile, const cdd&, cdd_print_varloc_f printer1, cdd_print_clockdiff_f printer2,
-                                 void* dict);
+    friend void cdd_fprintdot(FILE* ofile, const cdd&, bool push_negate);
+    friend void cdd_printdot(const cdd&, bool push_negate);
+    friend void cdd_fprint_code(FILE* ofile, const cdd&, cdd_print_varloc_f printer1,
+                                cdd_print_clockdiff_f printer2, void* dict);
+    friend void cdd_fprint_graph(FILE* ofile, const cdd&, cdd_print_varloc_f printer1,
+                                 cdd_print_clockdiff_f printer2, void* dict);
 #ifdef MULTI_TERMINAL
     friend cdd cdd_apply_tautology(const cdd&, int32_t);
     friend int32_t cdd_get_tautology_id(const cdd&);
@@ -1004,14 +1004,14 @@ inline cdd cdd_extract_dbm(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(c
  * @param ofile the file to write to.
  * @param cdd   a CDD.
  */
-inline void cdd_fprintdot(FILE* ofile, const cdd& cdd) { cdd_fprintdot(ofile, cdd.root); }
+inline void cdd_fprintdot(FILE* ofile, const cdd& cdd, bool push_negate) { cdd_fprintdot(ofile, cdd.root, push_negate); }
 
 /**
  * Print a CDD \a r as a dot input file to stdout.
  * @see cdd_fprintdot
  * @param cdd   a CDD.
  */
-inline void cdd_printdot(const cdd& cdd) { cdd_printdot(cdd.root); }
+inline void cdd_printdot(const cdd& cdd, bool push_negate) { cdd_printdot(cdd.root, push_negate); }
 
 /**
  * Another way of printing a BCDD

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -847,10 +847,10 @@ private:
     friend cdd cdd_extract_dbm(const cdd&, raw_t* dbm, int32_t dim);
     friend void cdd_fprintdot(FILE* ofile, const cdd&, bool push_negate);
     friend void cdd_printdot(const cdd&, bool push_negate);
-    friend void cdd_fprint_code(FILE* ofile, const cdd&, cdd_print_varloc_f printer1,
-                                cdd_print_clockdiff_f printer2, void* dict);
-    friend void cdd_fprint_graph(FILE* ofile, const cdd&, cdd_print_varloc_f printer1,
-                                 cdd_print_clockdiff_f printer2, void* dict);
+    friend void cdd_fprint_code(FILE* ofile, const cdd&, cdd_print_varloc_f printer1, cdd_print_clockdiff_f printer2,
+                                void* dict);
+    friend void cdd_fprint_graph(FILE* ofile, const cdd&, cdd_print_varloc_f printer1, cdd_print_clockdiff_f printer2,
+                                 void* dict);
 #ifdef MULTI_TERMINAL
     friend cdd cdd_apply_tautology(const cdd&, int32_t);
     friend int32_t cdd_get_tautology_id(const cdd&);
@@ -1021,7 +1021,10 @@ inline cdd cdd_extract_dbm(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(c
  * @param ofile the file to write to.
  * @param cdd   a CDD.
  */
-inline void cdd_fprintdot(FILE* ofile, const cdd& cdd, bool push_negate) { cdd_fprintdot(ofile, cdd.root, push_negate); }
+inline void cdd_fprintdot(FILE* ofile, const cdd& cdd, bool push_negate)
+{
+    cdd_fprintdot(ofile, cdd.root, push_negate);
+}
 
 /**
  * Print a CDD \a r as a dot input file to stdout.

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -483,6 +483,13 @@ extern ddNode* cdd_interval(int32_t i, int32_t j, raw_t lower, raw_t upper);
 extern ddNode* cdd_bddvar(int32_t level);
 
 /**
+ * Hopefully pushes negation down through the whole CDD structure
+ * @param node the node from where on the negation should be propagated
+ * @return the resulting negated node
+ */
+extern ddNode* cdd_push_negate(ddNode* node);
+
+/**
  * Performs a binary operation on two decision diagrams.
  * @param left  the left argument to the operation
  * @param right the right argument to the operation

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -580,11 +580,33 @@ extern ddNode* cdd_from_dbm(const raw_t* dbm, int32_t dim);
 extern ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t dim);
 
 /**
- * Print a CDD \a r as a dot input file \a ofile. You can use the dot
- * program from the graphwiz package to convert this to a PS picture
- * of the CDD.
+ * Print a CDD \a r as a dot input file \a ofile.\n\n
+ *
+ * Terminal nodes are printed as square nodes, where \a 1 represents the
+ * true node and \a 0 the false node.\n
+ *
+ * Clock-difference nodes are printed as octagons. All edges going to the
+ * false terminal node are omitted from being printed, as there might
+ * be a lot of them per clock difference.\n
+ *
+ * Boolean nodes are printed as circles.\n\n
+ *
+ * Negated nodes are printed in red. When \a push_negate is set to true, the
+ * negation of nodes is taken into account while printing the cdd. So the
+ * reached terminal node is the correct value. When \a push_negate is set
+ * to false, the cdd is printed as-is. The correct value for a particular
+ * variable assignment can be determined by counting the number of negated
+ * nodes (printed in red) along the path from the root node to the terminal
+ * and then negating the found terminal node if the counted number of negated
+ * nodes is odd.\n\n
+ *
+ * You can use, for example, the dot program from the graphwiz package to
+ * convert this to a PS picture of the CDD.
+ *
  * @param ofile the file to write to.
  * @param cdd   a CDD.
+ * @param push_negate when true printing takes negation into account, when
+ *      false the cdd is printed as-is.
  */
 extern void cdd_fprintdot(FILE* ofile, ddNode* cdd, bool push_negate);
 
@@ -592,6 +614,8 @@ extern void cdd_fprintdot(FILE* ofile, ddNode* cdd, bool push_negate);
  * Print a CDD \a r as a dot input file to stdout.
  * @see cdd_fprintdot
  * @param cdd   a CDD.
+ * @param push_negate when true printing takes negation into account, when
+ *      false the cdd is printed as-is.
  */
 extern void cdd_printdot(ddNode* cdd, bool push_negate);
 

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -483,13 +483,6 @@ extern ddNode* cdd_interval(int32_t i, int32_t j, raw_t lower, raw_t upper);
 extern ddNode* cdd_bddvar(int32_t level);
 
 /**
- * Hopefully pushes negation down through the whole CDD structure
- * @param node the node from where on the negation should be propagated
- * @return the resulting negated node
- */
-extern ddNode* cdd_push_negate(ddNode* node);
-
-/**
  * Performs a binary operation on two decision diagrams.
  * @param left  the left argument to the operation
  * @param right the right argument to the operation

--- a/include/cdd/kernel.h
+++ b/include/cdd/kernel.h
@@ -65,6 +65,9 @@ extern "C" {
 /** Returns the unmarked pointer to \a node */
 #define cdd_rglr(node) ((ddNode*)(((uintptr_t)(node)) & ~0x1))
 
+/** Returns the last bit (negated or true) of a \a node */
+#define cdd_is_negated(node) ((((uintptr_t)(node)) & 1))
+
 /** Returns a marked pointer to \a node */
 #define cdd_mask(node) (((uintptr_t)(node)) & 0x1)
 

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -9,20 +9,21 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "bellmanford.h"
-#include "cache.h"
-#include "tarjan.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
+#include "base/intutils.h"
+#include "base/bitstring.h"
 #include "dbm/dbm.h"
 #include "dbm/mingraph.h"
 #include "dbm/print.h"
-#include "cdd/kernel.h"
-#include "base/bitstring.h"
-#include "base/intutils.h"
+#include "debug/malloc.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "cdd/kernel.h"
+#include "cache.h"
+#include "bellmanford.h"
+#include "tarjan.h"
 
 #define RELAXCACHE
 
@@ -42,7 +43,8 @@
 #define REPLACEHASH(r)      ((uintptr_t)r)
 
 #ifdef RELAXCACHE
-#define RELAXHASH(n, l, c1, c2, u) (cdd_triple((uintptr_t)(node), cdd_pair((l), (c1)), cdd_pair((c2), (u))))
+#define RELAXHASH(n, l, c1, c2, u) \
+    (cdd_triple((uintptr_t)(node), cdd_pair((l), (c1)), cdd_pair((c2), (u))))
 #endif
 
 // #define cdd_and(l,r) cdd_apply_reduce((l), (r), cddop_and)
@@ -80,7 +82,7 @@ void cdd2Dot(char* fname, ddNode* node, char* name);
 
 /*=== INTERNAL PROTOTYPES ==============================================*/
 static int32_t cdd_contains_rec(ddNode*, raw_t*, int32_t dim);
-static ddNode* cdd_apply_rec(ddNode*, ddNode*);
+static ddNode* cdd_apply_rec(ddNode*, ddNode*, bool forced);
 #ifdef EX
 static ddNode* cdd_exist_rec(ddNode* node, int32_t*, int32_t*, raw_t*);
 #else
@@ -138,11 +140,12 @@ void cdd_operator_flush()
 #endif
 }
 
-ddNode* cdd_apply(ddNode* l, ddNode* h, int32_t op)
+
+ddNode* cdd_apply_forced(ddNode* l, ddNode* h, int32_t op)
 {
     ddNode* res;
     applyop = op;
-    res = cdd_apply_rec(l, h);
+    res = cdd_apply_rec(l, h, true);
     if (cdd_errorcond) {
         cdd_error(cdd_errorcond);
         return NULL;
@@ -150,7 +153,24 @@ ddNode* cdd_apply(ddNode* l, ddNode* h, int32_t op)
     return res;
 }
 
-static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
+ddNode* cdd_push_negate(ddNode* r) {
+    return cdd_apply_forced(r, r, cddop_and);
+}
+
+
+ddNode* cdd_apply(ddNode* l, ddNode* h, int32_t op)
+{
+    ddNode* res;
+    applyop = op;
+    res = cdd_apply_rec(l, h, false);
+    if (cdd_errorcond) {
+        cdd_error(cdd_errorcond);
+        return NULL;
+    }
+    return res;
+}
+
+static ddNode* cdd_apply_rec(ddNode* l, ddNode* r, bool forced)
 {
     CddCacheData* entry;
     int32_t lmask;
@@ -174,60 +194,62 @@ static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
     }
 
     /* Termination conditons */
-    switch (applyop) {
-    case cddop_and:
-        if (l == r || r == cddtrue) {
+    if (!forced) {
+        switch (applyop) {
+            case cddop_and:
+                if (l == r || r == cddtrue) {
+                    return l;
+                }
+                if (l == cddfalse || r == cddfalse || l == cdd_neg(r)) {
+                    return cddfalse;
+                }
+                if (l == cddtrue) {
+                    return r;
+                }
+                break;
+            case cddop_xor:
+                if (l == r) {
+                    return cddfalse;
+                }
+                if (l == cdd_neg(r)) {
+                    return cddtrue;
+                }
+                if (l == cddfalse) {
+                    return r;
+                }
+                if (r == cddfalse) {
+                    return l;
+                }
+                if (l == cddtrue) {
+                    return cdd_neg(r);
+                }
+                if (r == cddtrue) {
+                    return cdd_neg(l);
+                }
+                break;
+        }
+
+    }
+        /* The operation is symmetric; normalise for better cache performance */
+        if (l > r) {
+            n = l;
+            l = r;
+            r = n;
+        }
+
+        if (cdd_isterminal(l) && cdd_isterminal(r)) {
+            /* This may happen only for extra terminals and it
+             * is strange. We may return either of l or r.
+             */
+    #ifdef MULTI_TERMINAL
+            assert(cdd_is_extra_terminal(l) && cdd_is_extra_terminal(r));
+    #endif
+            if (l != r) {
+                fprintf(stderr, "Diagram is wrong: '%s' between extra terminal nodes.\n",
+                        applyop == cddop_and ? "and" : "xor");
+            }
             return l;
         }
-        if (l == cddfalse || r == cddfalse || l == cdd_neg(r)) {
-            return cddfalse;
-        }
-        if (l == cddtrue) {
-            return r;
-        }
-        break;
-    case cddop_xor:
-        if (l == r) {
-            return cddfalse;
-        }
-        if (l == cdd_neg(r)) {
-            return cddtrue;
-        }
-        if (l == cddfalse) {
-            return r;
-        }
-        if (r == cddfalse) {
-            return l;
-        }
-        if (l == cddtrue) {
-            return cdd_neg(r);
-        }
-        if (r == cddtrue) {
-            return cdd_neg(l);
-        }
-        break;
-    }
-
-    /* The operation is symmetric; normalise for better cache performance */
-    if (l > r) {
-        n = l;
-        l = r;
-        r = n;
-    }
-
-    if (cdd_isterminal(l) && cdd_isterminal(r)) {
-        /* This may happen only for extra terminals and it
-         * is strange. We may return either of l or r.
-         */
-#ifdef MULTI_TERMINAL
-        assert(cdd_is_extra_terminal(l) && cdd_is_extra_terminal(r));
-#endif
-        if (l != r) {
-            fprintf(stderr, "Diagram is wrong: '%s' between extra terminal nodes.\n",
-                    applyop == cddop_and ? "and" : "xor");
-        }
-        return l;
-    }
 
     /* Do cache lookup */
     //    fprintf(stderr, "%u\n", APPLYHASH(l, r, applyop) % 10000);
@@ -270,7 +292,7 @@ static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
         first = cdd_refstacktop;
 
         /* Do first recursion - check whether first edge is negated */
-        prev = cdd_apply_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask));
+        prev = cdd_apply_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask), forced);
         cdd_ref(prev);
         mask = cdd_mask(prev);
         bnd = minimum(lp->bnd, rp->bnd);
@@ -279,7 +301,7 @@ static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
         while (bnd < INF) {
             lp += (lp->bnd == bnd);
             rp += (rp->bnd == bnd);
-            n = cdd_apply_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask));
+            n = cdd_apply_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask), forced);
             if (n != prev) {
                 cdd_push(cdd_neg_cond(prev, mask), bnd);
                 prev = n;
@@ -290,7 +312,8 @@ static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
         cdd_push(cdd_neg_cond(prev, mask), INF);
 
         /* Create node */
-        entry->res = cdd_neg_cond(cdd_make_cdd_node(minimum(l->level, r->level), first, cdd_refstacktop - first), mask);
+        entry->res = cdd_neg_cond(
+            cdd_make_cdd_node(minimum(l->level, r->level), first, cdd_refstacktop - first), mask);
 
         /* Remove references */
         for (; first < cdd_refstacktop; first++) {
@@ -316,10 +339,11 @@ static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
             rl = rh = r;
         }
 
-        n = cdd_apply_rec(cdd_neg_cond(ll, lmask), cdd_neg_cond(rl, rmask));
+        n = cdd_apply_rec(cdd_neg_cond(ll, lmask), cdd_neg_cond(rl, rmask), forced);
         cdd_ref(n);
-        entry->res = cdd_make_bdd_node(minimum(l->level, r->level), n,
-                                       cdd_apply_rec(cdd_neg_cond(lh, lmask), cdd_neg_cond(rh, rmask)));
+        entry->res =
+            cdd_make_bdd_node(minimum(l->level, r->level), n,
+                              cdd_apply_rec(cdd_neg_cond(lh, lmask), cdd_neg_cond(rh, rmask), forced));
         cdd_deref(n);
     }
 
@@ -333,7 +357,8 @@ static ddNode* cdd_apply_rec(ddNode* l, ddNode* r)
 
 ///////////////////////////////////////////////////////////////////////////
 
-static bool cdd_constrain2(raw_t* dbm, uint32_t dim, uint32_t i, uint32_t j, raw_t lower, raw_t upper)
+static bool cdd_constrain2(raw_t* dbm, uint32_t dim, uint32_t i, uint32_t j, raw_t lower,
+                           raw_t upper)
 {
     constraint_t con[2] = {{j, i, bnd_l2u(lower)}, {i, j, upper}};
     return dbm_constrainN(dbm, dim, con, 2);
@@ -396,7 +421,8 @@ static int32_t cdd_contains_rec(ddNode* node, raw_t* d, int32_t dim)
         for (cdd_it_init(it, node); !cdd_it_atend(it); cdd_it_next(it)) {
             if (!IS_TRUE(cdd_it_child(it))) {
                 dbm_copy(tmp, d, dim);
-                if (cdd_constrain2(tmp, dim, info->clock1, info->clock2, cdd_it_lower(it), cdd_it_upper(it)) &&
+                if (cdd_constrain2(tmp, dim, info->clock1, info->clock2, cdd_it_lower(it),
+                                   cdd_it_upper(it)) &&
                     !cdd_contains_rec(cdd_it_child(it), tmp, dim)) {
                     free(tmp);
                     return 0;
@@ -636,7 +662,8 @@ static ddNode* cdd_exist_rec(ddNode* node, int32_t* levels, ddNode* c)
     return res;
 }
 #else
-static ddNode* relax(ddNode* node, int32_t* clocks, raw_t lower, int32_t clock1, int32_t clock2, raw_t upper, raw_t* rc)
+static ddNode* relax(ddNode* node, int32_t* clocks, raw_t lower, int32_t clock1, int32_t clock2,
+                     raw_t upper, raw_t* rc)
 {
     LevelInfo* info;
     cdd_iterator it;
@@ -660,8 +687,8 @@ static ddNode* relax(ddNode* node, int32_t* clocks, raw_t lower, int32_t clock1,
 
 #ifdef RELAXCACHE
     entry = CddCache_lookup(&relaxcache, RELAXHASH(node, lower, clock1, clock2, upper));
-    if (entry->node == node && entry->lower == lower && entry->upper == upper && entry->clock1 == clock1 &&
-        entry->clock2 == clock2 && entry->op == opid) {
+    if (entry->node == node && entry->lower == lower && entry->upper == upper &&
+        entry->clock1 == clock1 && entry->clock2 == clock2 && entry->op == opid) {
         if (cdd_rglr(entry->res)->ref == 0) {
             cdd_reclaim(entry->res);
         }
@@ -709,7 +736,8 @@ static ddNode* relax(ddNode* node, int32_t* clocks, raw_t lower, int32_t clock1,
 
             // Add consequence if tighter then those already removed
             if (pos > -1) {
-                if ((l > bnd_u2l(rc[neg * cdd_clocknum + pos])) || (u < rc[pos * cdd_clocknum + neg])) {
+                if ((l > bnd_u2l(rc[neg * cdd_clocknum + pos])) ||
+                    (u < rc[pos * cdd_clocknum + neg])) {
                     tmp3 = cdd_interval(pos, neg, maximum(l, bnd_u2l(rc[neg * cdd_clocknum + pos])),
                                         minimum(u, rc[pos * cdd_clocknum + neg]));
                     cdd_ref(tmp3);
@@ -725,7 +753,8 @@ static ddNode* relax(ddNode* node, int32_t* clocks, raw_t lower, int32_t clock1,
             }
 
             // Rebuild CDD by adding constraints from node
-            tmp3 = cdd_interval_from_level(cdd_rglr(node)->level, cdd_it_lower(it), cdd_it_upper(it));
+            tmp3 =
+                cdd_interval_from_level(cdd_rglr(node)->level, cdd_it_lower(it), cdd_it_upper(it));
             cdd_ref(tmp3);
 
             tmp4 = cdd_and(tmp2, tmp3);
@@ -814,8 +843,8 @@ static ddNode* cdd_exist_rec(ddNode* node, int32_t* levels, int32_t* clocks, raw
                 rc[info->clock2 * cdd_clocknum + info->clock1] = bnd_l2u(cdd_it_lower(it));
                 rc[info->clock1 * cdd_clocknum + info->clock2] = cdd_it_upper(it);
 
-                tmp1 =
-                    relax(cdd_it_child(it), clocks, cdd_it_lower(it), info->clock1, info->clock2, cdd_it_upper(it), rc);
+                tmp1 = relax(cdd_it_child(it), clocks, cdd_it_lower(it), info->clock1, info->clock2,
+                             cdd_it_upper(it), rc);
 
                 cdd_ref(tmp1);
 
@@ -838,7 +867,8 @@ static ddNode* cdd_exist_rec(ddNode* node, int32_t* levels, int32_t* clocks, raw
             }
         } else {
             while (!cdd_it_atend(it)) {
-                tmp1 = cdd_interval_from_level(cdd_rglr(node)->level, cdd_it_lower(it), cdd_it_upper(it));
+                tmp1 = cdd_interval_from_level(cdd_rglr(node)->level, cdd_it_lower(it),
+                                               cdd_it_upper(it));
                 cdd_ref(tmp1);
 
                 tmp2 = cdd_exist_rec(cdd_it_child(it), levels, clocks, rc);
@@ -938,7 +968,8 @@ static ddNode* cdd_replace_rec(ddNode* node, int32_t* levels, int32_t* clocks)
     case TYPE_CDD:
         res = cddfalse;
         for (cdd_it_init(it, node); !cdd_it_atend(it); cdd_it_next(it)) {
-            tmp1 = cdd_interval(clocks[info->clock1], clocks[info->clock2], cdd_it_lower(it), cdd_it_upper(it));
+            tmp1 = cdd_interval(clocks[info->clock1], clocks[info->clock2], cdd_it_lower(it),
+                                cdd_it_upper(it));
             cdd_ref(tmp1);
             tmp2 = cdd_replace_rec(cdd_it_child(it), levels, clocks);
             cdd_ref(tmp2);
@@ -1238,7 +1269,8 @@ static ddNode* cdd_reduce2_rec(ddNode* node)
             /* Calculate split */
             tmp1 = add_bound(prev, cdd_rglr(node)->level, low, cdd_it_lower(it));
             cdd_ref(tmp1);
-            tmp2 = add_bound(cdd_it_child(it), cdd_rglr(node)->level, cdd_it_lower(it), cdd_it_upper(it));
+            tmp2 = add_bound(cdd_it_child(it), cdd_rglr(node)->level, cdd_it_lower(it),
+                             cdd_it_upper(it));
             cdd_ref(tmp2);
             split = cdd_or(tmp1, tmp2);
             cdd_ref(split);
@@ -1338,8 +1370,9 @@ static ddNode* cdd_tarjan_reduce_rec(ddNode* node, struct tarjan* graph)
     case TYPE_BDD:
         n = cdd_tarjan_reduce_rec(cdd_neg_cond(bdd_node(node)->low, cdd_mask(node)), graph);
         cdd_ref(n);
-        m = cdd_make_bdd_node(cdd_rglr(node)->level, n,
-                              cdd_tarjan_reduce_rec(cdd_neg_cond(bdd_node(node)->high, cdd_mask(node)), graph));
+        m = cdd_make_bdd_node(
+            cdd_rglr(node)->level, n,
+            cdd_tarjan_reduce_rec(cdd_neg_cond(bdd_node(node)->high, cdd_mask(node)), graph));
         cdd_deref(n);
         break;
 
@@ -1407,7 +1440,8 @@ static ddNode* cdd_tarjan_reduce_rec(ddNode* node, struct tarjan* graph)
 
         /* Create node */
         if (modified) {
-            m = cdd_neg_cond(cdd_make_cdd_node(cdd_rglr(node)->level, top, cdd_refstacktop - top), mask);
+            m = cdd_neg_cond(cdd_make_cdd_node(cdd_rglr(node)->level, top, cdd_refstacktop - top),
+                             mask);
         } else {
             m = node;
         }
@@ -1511,10 +1545,12 @@ static ddNode* cdd_apply_reduce_rec(ddNode* l, ddNode* r, struct tarjan* graph)
         break;
 #ifdef MULTI_TERMINAL
         if (cdd_is_extra_terminal(l)) {
-            return cdd_mask(l) ? cdd_tarjan_reduce_rec(r, graph) : cdd_tarjan_reduce_rec(cdd_neg(r), graph);
+            return cdd_mask(l) ? cdd_tarjan_reduce_rec(r, graph)
+                               : cdd_tarjan_reduce_rec(cdd_neg(r), graph);
         }
         if (cdd_is_extra_terminal(r)) {
-            return cdd_mask(r) ? cdd_tarjan_reduce_rec(l, graph) : cdd_tarjan_reduce_rec(cdd_neg(l), graph);
+            return cdd_mask(r) ? cdd_tarjan_reduce_rec(l, graph)
+                               : cdd_tarjan_reduce_rec(cdd_neg(l), graph);
         }
 #endif
     }
@@ -1587,14 +1623,16 @@ static ddNode* cdd_apply_reduce_rec(ddNode* l, ddNode* r, struct tarjan* graph)
             bnd = minimum(lp->bnd, rp->bnd);
             if (bnd == dbm_LS_INFINITY) {
                 cdd_refstacktop = top;
-                return cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask), graph);
+                return cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask),
+                                            cdd_neg_cond(rp->child, rmask), graph);
             }
             cdd_tarjan_push(graph, info->clock1, info->clock2, bnd);
         }
 
         /* Do first recursion - check whether first edge is negated.
          */
-        prev = cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask), graph);
+        prev = cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask),
+                                    graph);
         cdd_ref(prev);
         mask = cdd_mask(prev);
         cdd_tarjan_pop(graph, info->clock1);
@@ -1612,7 +1650,8 @@ static ddNode* cdd_apply_reduce_rec(ddNode* l, ddNode* r, struct tarjan* graph)
         cdd_tarjan_push(graph, info->clock2, info->clock1, bnd_l2u(lower));
         while (bnd < INF && cdd_tarjan_consistent(graph)) {
             cdd_tarjan_push(graph, info->clock1, info->clock2, bnd);
-            n = cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask), graph);
+            n = cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask),
+                                     graph);
             cdd_tarjan_pop(graph, info->clock1);
             cdd_tarjan_pop(graph, info->clock2);
 
@@ -1634,7 +1673,8 @@ static ddNode* cdd_apply_reduce_rec(ddNode* l, ddNode* r, struct tarjan* graph)
          * only if the path is consistent.
          */
         if (bnd == INF && cdd_tarjan_consistent(graph)) {
-            n = cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask), graph);
+            n = cdd_apply_reduce_rec(cdd_neg_cond(lp->child, lmask), cdd_neg_cond(rp->child, rmask),
+                                     graph);
             if (n != prev) {
                 cdd_push(cdd_neg_cond(prev, mask), lower);
                 prev = n;
@@ -1649,7 +1689,8 @@ static ddNode* cdd_apply_reduce_rec(ddNode* l, ddNode* r, struct tarjan* graph)
 
         /* Create node.
          */
-        res = cdd_neg_cond(cdd_make_cdd_node(minimum(l->level, r->level), first, cdd_refstacktop - first), mask);
+        res = cdd_neg_cond(
+            cdd_make_cdd_node(minimum(l->level, r->level), first, cdd_refstacktop - first), mask);
 
         /* Remove references.
          */
@@ -1679,8 +1720,9 @@ static ddNode* cdd_apply_reduce_rec(ddNode* l, ddNode* r, struct tarjan* graph)
 
         n = cdd_apply_reduce_rec(cdd_neg_cond(ll, lmask), cdd_neg_cond(rl, rmask), graph);
         cdd_ref(n);
-        res = cdd_make_bdd_node(minimum(l->level, r->level), n,
-                                cdd_apply_reduce_rec(cdd_neg_cond(lh, lmask), cdd_neg_cond(rh, rmask), graph));
+        res = cdd_make_bdd_node(
+            minimum(l->level, r->level), n,
+            cdd_apply_reduce_rec(cdd_neg_cond(lh, lmask), cdd_neg_cond(rh, rmask), graph));
         cdd_deref(n);
     }
 

--- a/src/print.c
+++ b/src/print.c
@@ -108,7 +108,7 @@ int insertArray( Array *a, const char *element )
 
 bool contains(Array *a, const char *element )
 {
-    printf("%i",a->used);
+    //printf("%i",a->used);
     for (int i=0; i < a->used;i++)
     {
         //printf("%s : %s -> %i \n    ", a->array[i], element, strcmp(a->array[i], element));
@@ -219,14 +219,14 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
 
         // marking destroys printing of BDDs but might be important for CDD
         if (cdd_ismarked(r)) {
-            printf("print.c: a marked node has been reached during printing\n");
+            //printf("print.c: a marked node has been reached during printing\n");
             return;
         }
 
         //printf("cdd node");
         raw_t bnd = -INF;
-        cddNode* node = cdd_node(r);
-        Elem* p = node->elem;
+        cddNode *node = cdd_node(r);
+        Elem *p = node->elem;
 
         char *current_neg_appendix = "0";
         char *child_neg_appendix = "0";
@@ -234,15 +234,11 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         // we do not care about whether the current node is negated, only about whether it was reached via a negation
         if (negated) current_neg_appendix = "1";
         // to see if its children are reached via negation, we do need to take the current one into account
-        if (cdd_is_negated(r) ^ negated)
-        {
+        if (cdd_is_negated(r) ^ negated) {
             child_neg_appendix = "1";
         }
 
         // terminal children nodes don't need the annotation
-        if (cdd_isterminal((void *) node->next))
-            child_neg_appendix="";
-
 
         fprintf(ofile, "\"%p%s\" [shape=octagon, color = %s, label=\"x%d-x%d\"];\n", (void*)r, current_neg_appendix, node_color, cdd_info(node)->clock1,
                 cdd_info(node)->clock2);
@@ -250,11 +246,18 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         do {
             ddNode* child = p->child;
             if (child != cddfalse) {
+                if (child == cddfalse | child == cddtrue)
+                {
+                    child_neg_appendix = "";
+                }
+
                 fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=%s, label=\"", (void*)r, current_neg_appendix,
-                        (void*)cdd_rglr(child), child_neg_appendix, cdd_mask(child) ? "dashed" : "filled");
+                        (void*)(child), child_neg_appendix, cdd_mask(child) ? "dashed" : "filled");
                 printInterval(ofile, bnd, p->bnd);
                 fprintf(ofile, "\"];\n");
-                cdd_fprintdot_rec(ofile, cdd_rglr(child), flip_negated, negated ^ cdd_is_negated(r),a);
+
+                // TODO: here originally, the child node was regularized.. should I have kept that??
+                cdd_fprintdot_rec(ofile, child, flip_negated, negated ^ cdd_is_negated(r),a);
             }
             bnd = p->bnd;
             p++;

--- a/src/print.c
+++ b/src/print.c
@@ -140,6 +140,7 @@ void cdd_fprintdot(FILE* ofile, ddNode* r)
         cdd_print_terminal_node(ofile,cddtrue, 1);
         cdd_print_terminal_node(ofile,cddfalse, 0);
 
+        r = cdd_push_negate(r);
         cdd_fprintdot_rec(ofile, r);
     }
     fprintf(ofile, "}\n");

--- a/src/print.c
+++ b/src/print.c
@@ -217,8 +217,8 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         }
     } else {
 
-        // marking destroys printing of BDDs but might be important for CDD
-        if (cdd_ismarked(r)) {
+        // regularizing before checking whether a node is marked
+        if (cdd_ismarked(cdd_rglr(r))) {
             //printf("print.c: a marked node has been reached during printing\n");
             return;
         }

--- a/src/print.c
+++ b/src/print.c
@@ -111,34 +111,29 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r)
 
     cdd_setmark(r);
 }
+void cdd_print_terminal_node(FILE* ofile, ddNode* r, int label)
+{
+    fprintf(ofile,
+            "\"%p\" [shape=box, label=\"%d\", style=filled, shape=box, height=0.3, width=0.3];\n",
+            (void *) r, label);
+}
 
+
+// main print function called from outside
 void cdd_fprintdot(FILE* ofile, ddNode* r)
 {
-
+    fprintf(ofile, "digraph G {\n");
     if (cdd_isterminal(r))
     {
         bool bit = cdd_is_negated(r);
-
-        fprintf(ofile, "digraph G {\n");
-        fprintf(ofile,
-                "\"%p\" [shape=box, label=\"%d\", style=filled, shape=box, height=0.3, width=0.3];\n",
-                (void *) r, bit);
+        cdd_print_terminal_node(ofile, r, bit);
     }
     else {
-        fprintf(ofile, "digraph G {\n");
-        fprintf(ofile,
-                "\"%p\" [shape=box, label=\"0\", style=filled, shape=box, height=0.3, width=0.3];\n",
-                (void *) cddfalse);
-        // Print the true terminal (might not be connected to anything)
-        // TODO: Print fake root if r is negated <-- old comment
-        fprintf(ofile,
-                "\"%p\" [shape=box, label=\"1\", style=filled, shape=box, height=0.3, width=0.3];\n",
-                (void *) cddtrue);
+        cdd_print_terminal_node(ofile,cddfalse, 0);
+        cdd_print_terminal_node(ofile,cddtrue, 1);
 
         cdd_fprintdot_rec(ofile, r);
     }
-
-
     fprintf(ofile, "}\n");
     cdd_unmark(r);
 }

--- a/src/print.c
+++ b/src/print.c
@@ -55,22 +55,88 @@ static void printInterval(FILE* ofile, raw_t lower, raw_t upper)
 }
 
 
+/* Define a dynamic array of strings and its functions, to store pointers of nodes we have already visited
+ */
+typedef struct {
+
+    size_t used;
+    size_t size;
+    char ( *array )[40];
+} Array;
+
+
+int initArray( Array *a, size_t initialSize)
+{
+    a->used = 0;
+
+    a->array = malloc( initialSize * sizeof( char[40] ) );
+    int success = a->array != NULL;
+
+    if ( success )
+    {
+        a->size = initialSize;
+    }
+    else
+    {
+        a->size = 0;
+    }
+
+    return success;
+}
+
+int insertArray( Array *a, const char *element )
+{
+    int success = 1;
+
+    if ( a->used == a->size )
+    {
+        char ( *tmp )[40] = realloc( a->array, 2 * a->size * sizeof( char[40] ) );
+        if ( ( success = tmp != NULL ) )
+        {
+            a->array = tmp;
+            a->size *= 2;
+        }
+    }
+
+    if ( success )
+    {
+        strcpy( a->array[a->used++], element );
+    }
+
+    return success;
+}
+
+bool contains(Array *a, const char *element )
+{
+    printf("%i",a->used);
+    for (int i=0; i < a->used;i++)
+    {
+        //printf("%s : %s -> %i \n    ", a->array[i], element, strcmp(a->array[i], element));
+        if (strcmp(a->array[i], element)==0)
+            return true;
+    }
+    return false;
+}
+
+void freeArray(Array *a) {
+    free(a->array);
+    a->array = NULL;
+    a->used = a->size = 0;
+}
+
 
 /* Recursive function to print the nodes and edges of a CDD.  A side
  * effect of this function is that all nodes will be marked. All
  * previously marked nodes are ignored.
  */
-static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool negated)
+static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool negated, Array *a)
 {
     // we decided against regularizing because we need to know the bit to print the negation correctly
     //assert(cdd_rglr(r) == r);
 
-
     if (cdd_isterminal(r)) {
         return;
     }
-
-
 
     // this check was moved inside CDD part
     /*if (cdd_ismarked(r)) {
@@ -78,9 +144,15 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         return;
     }*/
 
+    // establish color for printing the node
+    char *node_color = "black";
+    if (cdd_is_negated(r))
+        node_color = "red";
+
     if (cdd_info(r)->type == TYPE_BDD) {
         bddNode* node = bdd_node(r);
 
+        // printf("bdd node");
         // we annotate each location in the dot file with a 0 if it was reached with an even number of negations,
         // and with a 1 if it was reached with an odd number of negations.
         char *current_neg_appendix = "0";
@@ -89,7 +161,7 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
 
         // we do not care about whether the current node is negated, only about whether it was reached via a negation
         if (negated) current_neg_appendix = "1";
-        // to see if its children are reached via negation, we do need to take the current one into account
+        // to see if its children are reached via negation, we do need to take the current negation into account
         if (cdd_is_negated(r) ^ negated)
         {
             high_neg_appendix = "1";
@@ -103,38 +175,46 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
             low_neg_appendix="";
 
 
-        // establish color for printing the node
-        char *node_color = "black";
-        if (cdd_is_negated(r))
-            node_color = "red";
+        //we chech whether we already reached this node via an array of strings keeping track of the pointers plus appendix
+        char buf[40] = {0};
+        snprintf(buf, sizeof buf, "%p%s\n", (void *) r, current_neg_appendix);
 
-        // print current node
-        fprintf(ofile, "\"%p%s\" [shape=circle, color = %s, label=\"b%d\"];\n", (void *) r, current_neg_appendix, node_color, node->level);
 
-        // print arrow to high
-        if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void *) node->high)) {
-            // flip arrow to the negated terminal if we had negation
-            fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"filled", (void *) r, current_neg_appendix, cdd_neg((void *) node->high));
-            fprintf(ofile, "\"];\n");
-        } else {
-            // print normal arrows with annotation for children
-            fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"filled", (void *) r, current_neg_appendix, (void *) node->high, high_neg_appendix);
-            fprintf(ofile, "\"];\n");
+        if (!contains(a,buf)) {
+            insertArray(a, buf);
+
+            // print current node
+            fprintf(ofile, "\"%p%s\" [shape=circle, color = %s, label=\"b%d\"];\n", (void *) r, current_neg_appendix,
+                    node_color, node->level);
+
+            // print arrow to high
+            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void *) node->high)) {
+                // flip arrow to the negated terminal if we had negation
+                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"filled", (void *) r, current_neg_appendix,
+                        cdd_neg((void *) node->high));
+                fprintf(ofile, "\"];\n");
+            } else {
+                // print normal arrows with annotation for children
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"filled", (void *) r, current_neg_appendix,
+                        (void *) node->high, high_neg_appendix);
+                fprintf(ofile, "\"];\n");
+            }
+            // print arrow to low
+            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void *) node->low)) {
+                // flip arrow to the negated terminal if we had negation
+                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"dashed", (void *) r, current_neg_appendix,
+                        cdd_neg((void *) node->low));
+                fprintf(ofile, "\"];\n");
+            } else {
+                // print normal arrows with annotation for children
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"dashed", (void *) r, current_neg_appendix,
+                        (void *) node->low, low_neg_appendix);
+                fprintf(ofile, "\"];\n");
+            }
+
+            cdd_fprintdot_rec(ofile, node->high, flip_negated, negated ^ cdd_is_negated(r), a);
+            cdd_fprintdot_rec(ofile, node->low, flip_negated, negated ^ cdd_is_negated(r), a);
         }
-        // print arrow to low
-        if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void *) node->low)) {
-            // flip arrow to the negated terminal if we had negation
-            fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"dashed", (void *) r, current_neg_appendix, cdd_neg((void *) node->low));
-            fprintf(ofile, "\"];\n");
-        } else {
-            // print normal arrows with annotation for children
-            fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"dashed", (void *) r, current_neg_appendix, (void *) node->low, low_neg_appendix);
-            fprintf(ofile, "\"];\n");
-        }
-
-        cdd_fprintdot_rec(ofile, node->high, flip_negated, negated ^ cdd_is_negated(r));
-        cdd_fprintdot_rec(ofile, node->low, flip_negated, negated ^ cdd_is_negated(r));
-
     } else {
 
         // marking destroys printing of BDDs but might be important for CDD
@@ -143,21 +223,38 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
             return;
         }
 
+        //printf("cdd node");
         raw_t bnd = -INF;
         cddNode* node = cdd_node(r);
         Elem* p = node->elem;
 
-        fprintf(ofile, "\"%p\" [shape=octagon, label=\"x%d-x%d\"];\n", (void*)r, cdd_info(node)->clock1,
+        char *current_neg_appendix = "0";
+        char *child_neg_appendix = "0";
+
+        // we do not care about whether the current node is negated, only about whether it was reached via a negation
+        if (negated) current_neg_appendix = "1";
+        // to see if its children are reached via negation, we do need to take the current one into account
+        if (cdd_is_negated(r) ^ negated)
+        {
+            child_neg_appendix = "1";
+        }
+
+        // terminal children nodes don't need the annotation
+        if (cdd_isterminal((void *) node->next))
+            child_neg_appendix="";
+
+
+        fprintf(ofile, "\"%p%s\" [shape=octagon, color = %s, label=\"x%d-x%d\"];\n", (void*)r, current_neg_appendix, node_color, cdd_info(node)->clock1,
                 cdd_info(node)->clock2);
 
         do {
             ddNode* child = p->child;
             if (child != cddfalse) {
-                fprintf(ofile, "\"%p\" -> \"%p\" [style=%s, label=\"", (void*)r,
-                        (void*)cdd_rglr(child), cdd_mask(child) ? "dashed" : "filled");
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=%s, label=\"", (void*)r, current_neg_appendix,
+                        (void*)cdd_rglr(child), child_neg_appendix, cdd_mask(child) ? "dashed" : "filled");
                 printInterval(ofile, bnd, p->bnd);
                 fprintf(ofile, "\"];\n");
-                cdd_fprintdot_rec(ofile, cdd_rglr(child), flip_negated, false);
+                cdd_fprintdot_rec(ofile, cdd_rglr(child), flip_negated, negated ^ cdd_is_negated(r),a);
             }
             bnd = p->bnd;
             p++;
@@ -177,6 +274,9 @@ void cdd_print_terminal_node(FILE* ofile, ddNode* r, int label)
 // main print function called from outside
 void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
 {
+    Array a;
+    initArray(&a, 100);
+
     fprintf(ofile, "digraph G {\n");
     bool bit = cdd_is_negated(r);
     if (cdd_isterminal(r))
@@ -187,12 +287,14 @@ void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
         cdd_print_terminal_node(ofile,cddtrue, 1);
         cdd_print_terminal_node(ofile,cddfalse, 0);
         if (push_negate)
-            cdd_fprintdot_rec(ofile, r, true, false);
+            cdd_fprintdot_rec(ofile, r, true, false,&a);
         else
-            cdd_fprintdot_rec(ofile, r, false, false);
+            cdd_fprintdot_rec(ofile, r, false, false,&a );
     }
     fprintf(ofile, "}\n");
     cdd_unmark(r);
+
+    freeArray(&a);
 }
 
 void cdd_printdot(ddNode* r, bool push_negate) { cdd_fprintdot(stdout, r, push_negate); }

--- a/src/print.c
+++ b/src/print.c
@@ -119,6 +119,10 @@ void freeArray(Array *a)
  * Recursive function to print the nodes and edges of a CDD. A side
  * effect of this function is that all nodes will be marked. All
  * previously marked nodes are ignored.
+ *
+ * flip_negated Whether to take negated nodes into account.
+ * negated Whether this node is reached by (an odd number of) negated node(s).
+ * a Dynamic array keeping track of already printed boolean nodes and it's negation status.
  */
 static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool negated, Array *a)
 {
@@ -191,6 +195,7 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
             cdd_fprintdot_rec(ofile, node->high, flip_negated, negated ^ cdd_is_negated(r), a);
             cdd_fprintdot_rec(ofile, node->low, flip_negated, negated ^ cdd_is_negated(r), a);
         }
+
     } else {
         // Regularizing before checking whether a node is marked.
         if (cdd_ismarked(cdd_rglr(r))) {
@@ -218,8 +223,7 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
             ddNode* child = p->child;
             if (child != cddfalse) {
                 // Terminal children nodes don't need the annotation.
-                // TODO should this check be done before the previous if statement?
-                if (child == cddfalse | child == cddtrue) {
+                if (child == cddtrue) {
                     child_neg_appendix = "";
                 }
 
@@ -245,9 +249,7 @@ void cdd_print_terminal_node(FILE* ofile, ddNode* r, int label)
             (void*) r, label);
 }
 
-
 // Main print function called from outside.
-// TODO Finish proper doc of this method.
 void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
 {
     Array a;
@@ -272,7 +274,6 @@ void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
     freeArray(&a);
 }
 
-// TODO Finish proper doc of this method.
 void cdd_printdot(ddNode* r, bool push_negate) { cdd_fprintdot(stdout, r, push_negate); }
 
 /******** TIGA related extensions. *********/

--- a/src/print.c
+++ b/src/print.c
@@ -58,93 +58,75 @@ static void printInterval(FILE* ofile, raw_t lower, raw_t upper)
 /* Define a dynamic array of strings and its functions, to store pointers of nodes we have already visited
  */
 typedef struct {
-
     size_t used;
     size_t size;
     char ( *array )[40];
 } Array;
 
 
-int initArray( Array *a, size_t initialSize)
+int initArray(Array *a, size_t initialSize)
 {
     a->used = 0;
 
-    a->array = malloc( initialSize * sizeof( char[40] ) );
+    a->array = malloc(initialSize * sizeof(char[40]));
     int success = a->array != NULL;
 
-    if ( success )
-    {
+    if (success) {
         a->size = initialSize;
-    }
-    else
-    {
+    } else {
         a->size = 0;
     }
 
     return success;
 }
 
-int insertArray( Array *a, const char *element )
+int insertArray(Array *a, const char *element)
 {
     int success = 1;
 
-    if ( a->used == a->size )
-    {
-        char ( *tmp )[40] = realloc( a->array, 2 * a->size * sizeof( char[40] ) );
-        if ( ( success = tmp != NULL ) )
-        {
+    if (a->used == a->size) {
+        char (*tmp)[40] = realloc(a->array, 2 * a->size * sizeof(char[40]));
+        if (( success = tmp != NULL )) {
             a->array = tmp;
             a->size *= 2;
         }
     }
 
-    if ( success )
-    {
-        strcpy( a->array[a->used++], element );
+    if (success) {
+        strcpy(a->array[a->used++],element);
     }
 
     return success;
 }
 
-bool contains(Array *a, const char *element )
+bool contains(Array *a, const char *element)
 {
-    //printf("%i",a->used);
-    for (int i=0; i < a->used;i++)
-    {
-        //printf("%s : %s -> %i \n    ", a->array[i], element, strcmp(a->array[i], element));
-        if (strcmp(a->array[i], element)==0)
-            return true;
+    for (int i=0; i < a->used; i++) {
+        if (strcmp(a->array[i], element)==0) return true;
     }
     return false;
 }
 
-void freeArray(Array *a) {
+void freeArray(Array *a)
+{
     free(a->array);
     a->array = NULL;
     a->used = a->size = 0;
 }
 
 
-/* Recursive function to print the nodes and edges of a CDD.  A side
+/*
+ * Recursive function to print the nodes and edges of a CDD. A side
  * effect of this function is that all nodes will be marked. All
  * previously marked nodes are ignored.
  */
 static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool negated, Array *a)
 {
-    // we decided against regularizing because we need to know the bit to print the negation correctly
-    //assert(cdd_rglr(r) == r);
-
     if (cdd_isterminal(r)) {
         return;
     }
 
-    // this check was moved inside CDD part
-    /*if (cdd_ismarked(r)) {
-        printf("print.c: a marked node has been reached during printing\n");
-        return;
-    }*/
-
-    // establish color for printing the node
+    // Establish color for printing the node.
     char *node_color = "black";
     if (cdd_is_negated(r))
         node_color = "red";
@@ -152,63 +134,57 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
     if (cdd_info(r)->type == TYPE_BDD) {
         bddNode* node = bdd_node(r);
 
-        // printf("bdd node");
-        // we annotate each location in the dot file with a 0 if it was reached with an even number of negations,
+        // We annotate each location in the dot file with a 0 if it was reached with an even number of negations,
         // and with a 1 if it was reached with an odd number of negations.
         char *current_neg_appendix = "0";
         char *high_neg_appendix = "0";
         char *low_neg_appendix = "0";
 
-        // we do not care about whether the current node is negated, only about whether it was reached via a negation
+        // We do not care about whether the current node is negated, only about whether it was reached via a negation.
         if (negated) current_neg_appendix = "1";
-        // to see if its children are reached via negation, we do need to take the current negation into account
-        if (cdd_is_negated(r) ^ negated)
-        {
+        // To see if its children are reached via negation, we do need to take the current negation into account.
+        if (cdd_is_negated(r) ^ negated) {
             high_neg_appendix = "1";
             low_neg_appendix = "1";
         }
 
-        // terminal children nodes don't need the annotation
-        if (cdd_isterminal((void *) node->high))
-            high_neg_appendix="";
-        if (cdd_isterminal((void *) node->low))
-            low_neg_appendix="";
+        // Terminal children nodes don't need the annotation.
+        if (cdd_isterminal((void*) node->high)) high_neg_appendix="";
+        if (cdd_isterminal((void*) node->low)) low_neg_appendix="";
 
-
-        //we chech whether we already reached this node via an array of strings keeping track of the pointers plus appendix
+        // Check whether we already reached this node via an array of strings keeping track of the pointers plus appendix.
         char buf[40] = {0};
-        snprintf(buf, sizeof buf, "%p%s\n", (void *) r, current_neg_appendix);
-
+        snprintf(buf, sizeof buf, "%p%s\n", (void*) r, current_neg_appendix);
 
         if (!contains(a,buf)) {
             insertArray(a, buf);
 
-            // print current node
-            fprintf(ofile, "\"%p%s\" [shape=circle, color = %s, label=\"b%d\"];\n", (void *) r, current_neg_appendix,
+            // Print current node.
+            fprintf(ofile, "\"%p%s\" [shape=circle, color = %s, label=\"b%d\"];\n", (void*) r, current_neg_appendix,
                     node_color, node->level);
 
-            // print arrow to high
-            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void *) node->high)) {
-                // flip arrow to the negated terminal if we had negation
-                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"filled", (void *) r, current_neg_appendix,
-                        cdd_neg((void *) node->high));
+            // Print arrow to high.
+            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void*) node->high)) {
+                // Flip arrow to the negated terminal if we had negation.
+                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"filled", (void*) r, current_neg_appendix,
+                        cdd_neg((void*) node->high));
                 fprintf(ofile, "\"];\n");
             } else {
-                // print normal arrows with annotation for children
-                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"filled", (void *) r, current_neg_appendix,
-                        (void *) node->high, high_neg_appendix);
+                // Print normal arrows with annotation for children.
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"filled", (void*) r, current_neg_appendix,
+                        (void*) node->high, high_neg_appendix);
                 fprintf(ofile, "\"];\n");
             }
-            // print arrow to low
-            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void *) node->low)) {
-                // flip arrow to the negated terminal if we had negation
-                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"dashed", (void *) r, current_neg_appendix,
-                        cdd_neg((void *) node->low));
+            // Print arrow to low.
+            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void*) node->low)) {
+                // Flip arrow to the negated terminal if we had negation.
+                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"dashed", (void*) r, current_neg_appendix,
+                        cdd_neg((void*) node->low));
                 fprintf(ofile, "\"];\n");
             } else {
-                // print normal arrows with annotation for children
-                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"dashed", (void *) r, current_neg_appendix,
-                        (void *) node->low, low_neg_appendix);
+                // Print normal arrows with annotation for children.
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"dashed", (void*) r, current_neg_appendix,
+                        (void*) node->low, low_neg_appendix);
                 fprintf(ofile, "\"];\n");
             }
 
@@ -216,14 +192,11 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
             cdd_fprintdot_rec(ofile, node->low, flip_negated, negated ^ cdd_is_negated(r), a);
         }
     } else {
-
-        // regularizing before checking whether a node is marked
+        // Regularizing before checking whether a node is marked.
         if (cdd_ismarked(cdd_rglr(r))) {
-            //printf("print.c: a marked node has been reached during printing\n");
             return;
         }
 
-        //printf("cdd node");
         raw_t bnd = -INF;
         cddNode *node = cdd_node(r);
         Elem *p = node->elem;
@@ -231,32 +204,30 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         char *current_neg_appendix = "0";
         char *child_neg_appendix = "0";
 
-        // we do not care about whether the current node is negated, only about whether it was reached via a negation
+        // We do not care about whether the current node is negated, only about whether it was reached via a negation.
         if (negated) current_neg_appendix = "1";
-        // to see if its children are reached via negation, we do need to take the current one into account
+        // To see if its children are reached via negation, we do need to take the current one into account.
         if (cdd_is_negated(r) ^ negated) {
             child_neg_appendix = "1";
         }
 
-        // terminal children nodes don't need the annotation
-
-        fprintf(ofile, "\"%p%s\" [shape=octagon, color = %s, label=\"x%d-x%d\"];\n", (void*)r, current_neg_appendix, node_color, cdd_info(node)->clock1,
-                cdd_info(node)->clock2);
+        fprintf(ofile, "\"%p%s\" [shape=octagon, color = %s, label=\"x%d-x%d\"];\n", (void*) r, current_neg_appendix,
+                node_color, cdd_info(node)->clock1, cdd_info(node)->clock2);
 
         do {
             ddNode* child = p->child;
             if (child != cddfalse) {
-                if (child == cddfalse | child == cddtrue)
-                {
+                // Terminal children nodes don't need the annotation.
+                // TODO should this check be done before the previous if statement?
+                if (child == cddfalse | child == cddtrue) {
                     child_neg_appendix = "";
                 }
 
-                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=%s, label=\"", (void*)r, current_neg_appendix,
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=%s, label=\"", (void*) r, current_neg_appendix,
                         (void*)(child), child_neg_appendix, cdd_mask(child) ? "dashed" : "filled");
                 printInterval(ofile, bnd, p->bnd);
                 fprintf(ofile, "\"];\n");
 
-                // TODO: here originally, the child node was regularized.. should I have kept that??
                 cdd_fprintdot_rec(ofile, child, flip_negated, negated ^ cdd_is_negated(r),a);
             }
             bnd = p->bnd;
@@ -266,15 +237,17 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
 
     cdd_setmark(r);
 }
+
 void cdd_print_terminal_node(FILE* ofile, ddNode* r, int label)
 {
     fprintf(ofile,
             "\"%p\" [shape=box, label=\"%d\", style=filled, height=0.3, width=0.3];\n",
-            (void *) r, label);
+            (void*) r, label);
 }
 
 
-// main print function called from outside
+// Main print function called from outside.
+// TODO Finish proper doc of this method.
 void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
 {
     Array a;
@@ -282,17 +255,16 @@ void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
 
     fprintf(ofile, "digraph G {\n");
     bool bit = cdd_is_negated(r);
-    if (cdd_isterminal(r))
-    {
+    if (cdd_isterminal(r)) {
         cdd_print_terminal_node(ofile, r, bit);
     } else {
-
         cdd_print_terminal_node(ofile,cddtrue, 1);
         cdd_print_terminal_node(ofile,cddfalse, 0);
-        if (push_negate)
-            cdd_fprintdot_rec(ofile, r, true, false,&a);
-        else
-            cdd_fprintdot_rec(ofile, r, false, false,&a );
+        if (push_negate) {
+            cdd_fprintdot_rec(ofile, r, true, false, &a);
+        } else {
+            cdd_fprintdot_rec(ofile, r, false, false, &a);
+        }
     }
     fprintf(ofile, "}\n");
     cdd_unmark(r);
@@ -300,6 +272,7 @@ void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
     freeArray(&a);
 }
 
+// TODO Finish proper doc of this method.
 void cdd_printdot(ddNode* r, bool push_negate) { cdd_fprintdot(stdout, r, push_negate); }
 
 /******** TIGA related extensions. *********/

--- a/src/print.c
+++ b/src/print.c
@@ -9,10 +9,11 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <stdio.h>
-#include <stdlib.h>
 #include "cdd/kernel.h"
 #include "base/bitstring.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 
 typedef struct conditionList_ conditionList;
 typedef struct infor_ infor;
@@ -54,17 +55,16 @@ static void printInterval(FILE* ofile, raw_t lower, raw_t upper)
     }
 }
 
-
 /* Define a dynamic array of strings and its functions, to store pointers of nodes we have already visited
  */
-typedef struct {
+typedef struct
+{
     size_t used;
     size_t size;
-    char ( *array )[40];
+    char (*array)[40];
 } Array;
 
-
-int initArray(Array *a, size_t initialSize)
+int initArray(Array* a, size_t initialSize)
 {
     a->used = 0;
 
@@ -80,40 +80,40 @@ int initArray(Array *a, size_t initialSize)
     return success;
 }
 
-int insertArray(Array *a, const char *element)
+int insertArray(Array* a, const char* element)
 {
     int success = 1;
 
     if (a->used == a->size) {
-        char (*tmp)[40] = realloc(a->array, 2 * a->size * sizeof(char[40]));
-        if (( success = tmp != NULL )) {
+        char(*tmp)[40] = realloc(a->array, 2 * a->size * sizeof(char[40]));
+        if ((success = tmp != NULL)) {
             a->array = tmp;
             a->size *= 2;
         }
     }
 
     if (success) {
-        strcpy(a->array[a->used++],element);
+        strcpy(a->array[a->used++], element);
     }
 
     return success;
 }
 
-bool contains(Array *a, const char *element)
+bool contains(Array* a, const char* element)
 {
-    for (int i=0; i < a->used; i++) {
-        if (strcmp(a->array[i], element)==0) return true;
+    for (int i = 0; i < a->used; i++) {
+        if (strcmp(a->array[i], element) == 0)
+            return true;
     }
     return false;
 }
 
-void freeArray(Array *a)
+void freeArray(Array* a)
 {
     free(a->array);
     a->array = NULL;
     a->used = a->size = 0;
 }
-
 
 /*
  * Recursive function to print the nodes and edges of a CDD. A side
@@ -124,14 +124,14 @@ void freeArray(Array *a)
  * negated Whether this node is reached by (an odd number of) negated node(s).
  * a Dynamic array keeping track of already printed boolean nodes and it's negation status.
  */
-static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool negated, Array *a)
+static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool negated, Array* a)
 {
     if (cdd_isterminal(r)) {
         return;
     }
 
     // Establish color for printing the node.
-    char *node_color = "black";
+    char* node_color = "black";
     if (cdd_is_negated(r))
         node_color = "red";
 
@@ -140,12 +140,13 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
 
         // We annotate each location in the dot file with a 0 if it was reached with an even number of negations,
         // and with a 1 if it was reached with an odd number of negations.
-        char *current_neg_appendix = "0";
-        char *high_neg_appendix = "0";
-        char *low_neg_appendix = "0";
+        char* current_neg_appendix = "0";
+        char* high_neg_appendix = "0";
+        char* low_neg_appendix = "0";
 
         // We do not care about whether the current node is negated, only about whether it was reached via a negation.
-        if (negated) current_neg_appendix = "1";
+        if (negated)
+            current_neg_appendix = "1";
         // To see if its children are reached via negation, we do need to take the current negation into account.
         if (cdd_is_negated(r) ^ negated) {
             high_neg_appendix = "1";
@@ -153,42 +154,45 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         }
 
         // Terminal children nodes don't need the annotation.
-        if (cdd_isterminal((void*) node->high)) high_neg_appendix="";
-        if (cdd_isterminal((void*) node->low)) low_neg_appendix="";
+        if (cdd_isterminal((void*)node->high))
+            high_neg_appendix = "";
+        if (cdd_isterminal((void*)node->low))
+            low_neg_appendix = "";
 
-        // Check whether we already reached this node via an array of strings keeping track of the pointers plus appendix.
+        // Check whether we already reached this node via an array of strings keeping track of the pointers plus
+        // appendix.
         char buf[40] = {0};
-        snprintf(buf, sizeof buf, "%p%s\n", (void*) r, current_neg_appendix);
+        snprintf(buf, sizeof buf, "%p%s\n", (void*)r, current_neg_appendix);
 
-        if (!contains(a,buf)) {
+        if (!contains(a, buf)) {
             insertArray(a, buf);
 
             // Print current node.
-            fprintf(ofile, "\"%p%s\" [shape=circle, color = %s, label=\"b%d\"];\n", (void*) r, current_neg_appendix,
+            fprintf(ofile, "\"%p%s\" [shape=circle, color = %s, label=\"b%d\"];\n", (void*)r, current_neg_appendix,
                     node_color, node->level);
 
             // Print arrow to high.
-            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void*) node->high)) {
+            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void*)node->high)) {
                 // Flip arrow to the negated terminal if we had negation.
-                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"filled", (void*) r, current_neg_appendix,
-                        cdd_neg((void*) node->high));
+                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"filled", (void*)r, current_neg_appendix,
+                        cdd_neg((void*)node->high));
                 fprintf(ofile, "\"];\n");
             } else {
                 // Print normal arrows with annotation for children.
-                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"filled", (void*) r, current_neg_appendix,
-                        (void*) node->high, high_neg_appendix);
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"filled", (void*)r, current_neg_appendix,
+                        (void*)node->high, high_neg_appendix);
                 fprintf(ofile, "\"];\n");
             }
             // Print arrow to low.
-            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void*) node->low)) {
+            if (flip_negated && (negated ^ cdd_is_negated(r)) && cdd_isterminal((void*)node->low)) {
                 // Flip arrow to the negated terminal if we had negation.
-                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"dashed", (void*) r, current_neg_appendix,
-                        cdd_neg((void*) node->low));
+                fprintf(ofile, "\"%p%s\" -> \"%p\" [style=\"dashed", (void*)r, current_neg_appendix,
+                        cdd_neg((void*)node->low));
                 fprintf(ofile, "\"];\n");
             } else {
                 // Print normal arrows with annotation for children.
-                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"dashed", (void*) r, current_neg_appendix,
-                        (void*) node->low, low_neg_appendix);
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=\"dashed", (void*)r, current_neg_appendix, (void*)node->low,
+                        low_neg_appendix);
                 fprintf(ofile, "\"];\n");
             }
 
@@ -203,20 +207,21 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
         }
 
         raw_t bnd = -INF;
-        cddNode *node = cdd_node(r);
-        Elem *p = node->elem;
+        cddNode* node = cdd_node(r);
+        Elem* p = node->elem;
 
-        char *current_neg_appendix = "0";
-        char *child_neg_appendix = "0";
+        char* current_neg_appendix = "0";
+        char* child_neg_appendix = "0";
 
         // We do not care about whether the current node is negated, only about whether it was reached via a negation.
-        if (negated) current_neg_appendix = "1";
+        if (negated)
+            current_neg_appendix = "1";
         // To see if its children are reached via negation, we do need to take the current one into account.
         if (cdd_is_negated(r) ^ negated) {
             child_neg_appendix = "1";
         }
 
-        fprintf(ofile, "\"%p%s\" [shape=octagon, color = %s, label=\"x%d-x%d\"];\n", (void*) r, current_neg_appendix,
+        fprintf(ofile, "\"%p%s\" [shape=octagon, color = %s, label=\"x%d-x%d\"];\n", (void*)r, current_neg_appendix,
                 node_color, cdd_info(node)->clock1, cdd_info(node)->clock2);
 
         do {
@@ -227,12 +232,12 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
                     child_neg_appendix = "";
                 }
 
-                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=%s, label=\"", (void*) r, current_neg_appendix,
+                fprintf(ofile, "\"%p%s\" -> \"%p%s\" [style=%s, label=\"", (void*)r, current_neg_appendix,
                         (void*)(child), child_neg_appendix, cdd_mask(child) ? "dashed" : "filled");
                 printInterval(ofile, bnd, p->bnd);
                 fprintf(ofile, "\"];\n");
 
-                cdd_fprintdot_rec(ofile, child, flip_negated, negated ^ cdd_is_negated(r),a);
+                cdd_fprintdot_rec(ofile, child, flip_negated, negated ^ cdd_is_negated(r), a);
             }
             bnd = p->bnd;
             p++;
@@ -244,9 +249,7 @@ static void cdd_fprintdot_rec(FILE* ofile, ddNode* r, bool flip_negated, bool ne
 
 void cdd_print_terminal_node(FILE* ofile, ddNode* r, int label)
 {
-    fprintf(ofile,
-            "\"%p\" [shape=box, label=\"%d\", style=filled, height=0.3, width=0.3];\n",
-            (void*) r, label);
+    fprintf(ofile, "\"%p\" [shape=box, label=\"%d\", style=filled, height=0.3, width=0.3];\n", (void*)r, label);
 }
 
 // Main print function called from outside.
@@ -260,8 +263,8 @@ void cdd_fprintdot(FILE* ofile, ddNode* r, bool push_negate)
     if (cdd_isterminal(r)) {
         cdd_print_terminal_node(ofile, r, bit);
     } else {
-        cdd_print_terminal_node(ofile,cddtrue, 1);
-        cdd_print_terminal_node(ofile,cddfalse, 0);
+        cdd_print_terminal_node(ofile, cddtrue, 1);
+        cdd_print_terminal_node(ofile, cddfalse, 0);
         if (push_negate) {
             cdd_fprintdot_rec(ofile, r, true, false, &a);
         } else {
@@ -294,8 +297,8 @@ static void print_node2label(FILE* ofile, ddNode* node)
 }
 
 static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* parentInfo,
-                                 cdd_print_varloc_f labelPrinter,
-                                 cdd_print_clockdiff_f clockPrinter, void* data, int dotFormat)
+                                 cdd_print_varloc_f labelPrinter, cdd_print_clockdiff_f clockPrinter, void* data,
+                                 int dotFormat)
 {
     // We mark only the states which are printed (ie not the ones which are reduced)
     // Maybe a problem when calling cdd_unmark ? ("Does not recurse into a node which is not
@@ -340,11 +343,11 @@ static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* pa
         do {
             ddNode* child = p->child;
             if (child != cddfalse) {
-                cdd_freduce_dump_rec(ofile, maskSize, cdd_rglr(child), NULL, labelPrinter,
-                                     clockPrinter, data, dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, cdd_rglr(child), NULL, labelPrinter, clockPrinter, data,
+                                     dotFormat);
                 if (dotFormat) {
-                    fprintf(ofile, "\"%p\" -> \"%p\" [style=%s, label=\"", (void*)node,
-                            (void*)cdd_rglr(child), cdd_mask(child) ? "dashed" : "filled");
+                    fprintf(ofile, "\"%p\" -> \"%p\" [style=%s, label=\"", (void*)node, (void*)cdd_rglr(child),
+                            cdd_mask(child) ? "dashed" : "filled");
                     printInterval(ofile, bnd, p->bnd);
                     fprintf(ofile, "\"];\n");
                 } else {
@@ -352,13 +355,11 @@ static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* pa
                     fprintf(ofile, "_%p : if (", (void*)node);
                     ifstatement = 1;
                     clockPrinter(ofile, levinf->clock1, levinf->clock2, data);
-                    fprintf(ofile, "%s%d", dbm_rawIsWeak(lower) ? ">=" : ">",
-                            -dbm_raw2bound(lower));
+                    fprintf(ofile, "%s%d", dbm_rawIsWeak(lower) ? ">=" : ">", -dbm_raw2bound(lower));
                     if (p->bnd != dbm_LS_INFINITY) {
                         fprintf(ofile, " && ");
                         clockPrinter(ofile, levinf->clock1, levinf->clock2, data);
-                        fprintf(ofile, "%s%d", dbm_rawIsWeak(p->bnd) ? "<=" : "<",
-                                dbm_raw2bound(p->bnd));
+                        fprintf(ofile, "%s%d", dbm_rawIsWeak(p->bnd) ? "<=" : "<", dbm_raw2bound(p->bnd));
                     }
                     fprintf(ofile, ") goto ");
                     print_node2label(ofile, cdd_rglr(child));
@@ -376,8 +377,7 @@ static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* pa
         cdd_setmark(r);
     } else {
         bddNode* node = bdd_node(r);
-        if (parentInfo == NULL ||
-            (parentInfo->other != node->high && parentInfo->other != node->low)) {
+        if (parentInfo == NULL || (parentInfo->other != node->high && parentInfo->other != node->low)) {
             // No possible reduction, start exploration by low child
             infor myInfo;
             myInfo.current = node->low;
@@ -391,21 +391,18 @@ static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* pa
             }
             base_setOneBit(myInfo.mask, node->level);
             myInfo.stringFound = false;
-            cdd_freduce_dump_rec(ofile, maskSize, node->low, &myInfo, labelPrinter, clockPrinter,
-                                 data, dotFormat);
+            cdd_freduce_dump_rec(ofile, maskSize, node->low, &myInfo, labelPrinter, clockPrinter, data, dotFormat);
 
             // Exploration of high child
             if (myInfo.stringFound) {
                 // Do not search for any string in high child
-                cdd_freduce_dump_rec(ofile, maskSize, node->high, NULL, labelPrinter, clockPrinter,
-                                     data, dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, node->high, NULL, labelPrinter, clockPrinter, data, dotFormat);
             } else {
                 assert(*(myInfo.value) == 0);
                 myInfo.current = node->high;
                 myInfo.other = node->low;
                 base_setOneBit(myInfo.value, node->level);
-                cdd_freduce_dump_rec(ofile, maskSize, node->high, &myInfo, labelPrinter,
-                                     clockPrinter, data, dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, node->high, &myInfo, labelPrinter, clockPrinter, data, dotFormat);
             }
 
             // Print node, mask, value, and children
@@ -418,12 +415,10 @@ static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* pa
                 fprintf(ofile, "\"%p\" [label=\"_%p\"];\n", (void*)node, (void*)node);
 
                 if (myInfo.current != cddfalse) {
-                    fprintf(ofile, "\"%p\" -> \"%p\" [style=filled];\n", (void*)node,
-                            (void*)myInfo.current);
+                    fprintf(ofile, "\"%p\" -> \"%p\" [style=filled];\n", (void*)node, (void*)myInfo.current);
                 }
                 if (myInfo.other != cddfalse) {
-                    fprintf(ofile, "\"%p\" -> \"%p\" [style=dashed];\n", (void*)node,
-                            (void*)myInfo.other);
+                    fprintf(ofile, "\"%p\" -> \"%p\" [style=dashed];\n", (void*)node, (void*)myInfo.other);
                 }
             } else {
                 fprintf(ofile, "_%p: if ", (void*)node);
@@ -443,25 +438,23 @@ static void cdd_freduce_dump_rec(FILE* ofile, int maskSize, ddNode* r, infor* pa
             base_setOneBit(parentInfo->mask, node->level);
             if (parentInfo->other == node->high) {
                 parentInfo->current = node->low;
-                cdd_freduce_dump_rec(ofile, maskSize, node->low, parentInfo, labelPrinter,
-                                     clockPrinter, data, dotFormat);
-                cdd_freduce_dump_rec(ofile, maskSize, node->high, NULL, labelPrinter, clockPrinter,
-                                     data, dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, node->low, parentInfo, labelPrinter, clockPrinter, data,
+                                     dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, node->high, NULL, labelPrinter, clockPrinter, data, dotFormat);
             } else {
                 assert(parentInfo->other == node->low);
                 parentInfo->current = node->high;
                 base_setOneBit(parentInfo->value, node->level);
-                cdd_freduce_dump_rec(ofile, maskSize, node->high, parentInfo, labelPrinter,
-                                     clockPrinter, data, dotFormat);
-                cdd_freduce_dump_rec(ofile, maskSize, node->low, NULL, labelPrinter, clockPrinter,
-                                     data, dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, node->high, parentInfo, labelPrinter, clockPrinter, data,
+                                     dotFormat);
+                cdd_freduce_dump_rec(ofile, maskSize, node->low, NULL, labelPrinter, clockPrinter, data, dotFormat);
             }
         }
     }
 }
 
-void cdd_fprint_code(FILE* ofile, ddNode* r, cdd_print_varloc_f labelPrinter,
-                     cdd_print_clockdiff_f clockPrinter, void* data)
+void cdd_fprint_code(FILE* ofile, ddNode* r, cdd_print_varloc_f labelPrinter, cdd_print_clockdiff_f clockPrinter,
+                     void* data)
 {
     assert(labelPrinter);
     assert(clockPrinter);
@@ -474,8 +467,8 @@ void cdd_fprint_code(FILE* ofile, ddNode* r, cdd_print_varloc_f labelPrinter,
     cdd_force_unmark(r);
 }
 
-void cdd_fprint_graph(FILE* ofile, ddNode* r, cdd_print_varloc_f labelPrinter,
-                      cdd_print_clockdiff_f clockPrinter, void* data)
+void cdd_fprint_graph(FILE* ofile, ddNode* r, cdd_print_varloc_f labelPrinter, cdd_print_clockdiff_f clockPrinter,
+                      void* data)
 {
     assert(labelPrinter);
     assert(clockPrinter);


### PR DESCRIPTION
The original print function could not handle negated nodes. This merge requests allows CDDs with negated nodes to be printed correctly.