### PR TITLE
Fix hash function

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -135,7 +135,7 @@ static void cdd_rehash(NodeManager*, SubTable*);
 /**
  * Hash function used to pair two DD nodes.
  */
-#define bddHash(f, g) ((((uint32_t)(f)*DD_P1 + (uint32_t)(g)) * DD_P2))
+#define bddHash(f, g) ((uint32_t)(((uint32_t)(f)*DD_P1 + (uint32_t)(g)) * DD_P2))
 
 /**
  * Hash function over an array of \a len Elem elements.


### PR DESCRIPTION
The original BDD hash function resulted in memory problems (probably never spotted, as the BDD part of the CDD library seemed to be not actively used before).

Written together with @florber and Ulrik Nyman.