### PR TITLE
force to use wine when running unit tests

### DIFF
--- a/toolchains/mingw.cmake
+++ b/toolchains/mingw.cmake
@@ -1,5 +1,7 @@
 # the name of the target operating system
 set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_CROSSCOMPILING ON)
+set(CMAKE_CROSSCOMPILING_EMULATOR wine)
 
 # which compilers to use for C and C++
 set(CMAKE_C_COMPILER   x86_64-w64-mingw32-gcc)


### PR DESCRIPTION
CI tests are failing to run again due to "File does not contain a valid CIL image" (see other PRs).
Something fishy is going on with executing windows programs in Linux environment (binfmt should help the kernel identify the binary and use wine), perhaps it's WSL afterall and not Linux anymore.
Let's use force.