### PR TITLE
Make cdd equiv externally available

### DIFF
--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -342,11 +342,9 @@ extern int32_t cdd_get_number_of_tautologies();
 extern int32_t cdd_get_level_count();
 
 /**
- * checks for equivalence between two cdds
+ * Checks for equivalence between two CDDs.
  */
-extern  int32_t cdd_equiv(ddNode* c, ddNode* d);
-
-
+extern int32_t cdd_equiv(ddNode* c, ddNode* d);
 
 /**
  * Returns the number of BDD levels.
@@ -929,13 +927,9 @@ inline cdd cdd_lowerpp(int32_t i, int32_t j, raw_t bound) { return cdd(cdd_neg(c
 inline cdd cdd_remove_negative(const cdd& node) { return cdd(cdd_remove_negative(node.handle())); }
 
 /**
- * checks for equivalence between two cdds
+ * Checks for equivalence between two CDDs.
  */
-inline bool  cdd_equiv(const cdd& l, const cdd& r)
-{
-    return cdd_equiv(l.root,r.root);
-}
-
+inline bool cdd_equiv(const cdd& l, const cdd& r) { return cdd_equiv(l.root, r.root); }
 
 /**
  * Creates a new CDD node corresponding to the constraint \a lower

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -342,6 +342,13 @@ extern int32_t cdd_get_number_of_tautologies();
 extern int32_t cdd_get_level_count();
 
 /**
+ * checks for equivalence between two cdds
+ */
+extern  int32_t cdd_equiv(ddNode* c, ddNode* d);
+
+
+
+/**
  * Returns the number of BDD levels.
  */
 extern int32_t cdd_get_bdd_level_count();
@@ -851,6 +858,7 @@ private:
     friend cdd cdd_apply_reduce(const cdd&, const cdd&, int);
     friend cdd cdd_ite(const cdd&, const cdd&, const cdd&);
     friend cdd cdd_reduce(const cdd&);
+    friend bool cdd_equiv(const cdd&, const cdd&);
     friend cdd cdd_reduce2(const cdd&);
     friend bool cdd_contains(const cdd&, raw_t* dbm, int32_t dim);
     friend cdd cdd_extract_dbm(const cdd&, raw_t* dbm, int32_t dim);
@@ -919,6 +927,15 @@ inline cdd cdd_lowerpp(int32_t i, int32_t j, raw_t bound) { return cdd(cdd_neg(c
  * @return a cdd that does not contain negative value
  */
 inline cdd cdd_remove_negative(const cdd& node) { return cdd(cdd_remove_negative(node.handle())); }
+
+/**
+ * checks for equivalence between two cdds
+ */
+inline bool  cdd_equiv(const cdd& l, const cdd& r)
+{
+    return cdd_equiv(l.root,r.root);
+}
+
 
 /**
  * Creates a new CDD node corresponding to the constraint \a lower

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -1198,7 +1198,7 @@ static ddNode* add_bound(ddNode* c, int32_t level, raw_t low, raw_t up)
     return tmp2;
 }
 
- int32_t cdd_equiv(ddNode* c, ddNode* d)
+int32_t cdd_equiv(ddNode* c, ddNode* d)
 {
     ddNode* tmp1;
     ddNode* tmp2;

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -1198,7 +1198,7 @@ static ddNode* add_bound(ddNode* c, int32_t level, raw_t low, raw_t up)
     return tmp2;
 }
 
-static int32_t equiv(ddNode* c, ddNode* d)
+ int32_t cdd_equiv(ddNode* c, ddNode* d)
 {
     ddNode* tmp1;
     ddNode* tmp2;
@@ -1261,7 +1261,7 @@ static ddNode* cdd_reduce2_rec(ddNode* node)
             cdd_ref(join);
 
             /* Are they equivalent ? */
-            if (equiv(split, join)) {
+            if (cdd_equiv(split, join)) {
                 /* Yes, use the union as the new prev */
                 cdd_rec_deref(prev);
                 prev = tmp1;

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -261,6 +261,26 @@ static void test_remove_negative(size_t size)
     REQUIRE(cdd4 != cdd3);
 }
 
+static void test_equiv(size_t size)
+{
+    cdd cdd1, cdd2, cdd3, cdd4;
+    auto dbm1 = dbm_wrap{size};
+    auto dbm2 = dbm_wrap{size};
+
+    // Generate DBMs:
+    dbm1.generate();
+    dbm2.generate();
+
+    // Create CDDs:
+    cdd1 = cdd(dbm1.raw(), size);
+    cdd2 = cdd(dbm2.raw(), size);
+    cdd3 = cdd1 & cdd2;
+    cdd4 = cdd2 & cdd1;
+
+    // Check the result:
+    REQUIRE(cdd_equiv(cdd3, cdd4));
+}
+
 static void test(const char* name, TestFunction f, size_t size)
 {
     cout << name << " size = " << size << endl;
@@ -286,6 +306,7 @@ void big_test(uint32_t n, uint32_t seed)
             test("test_intersection", test_intersection, i);
             test("test_apply_reduce", test_apply_reduce, i);
             test("test_reduce      ", test_reduce, i);
+            test("test_equiv       ", test_equiv, i);
         }
         test("test_remove_negative", test_remove_negative, n);
         passDBMs = dbm_wrap::get_allDBMs() - DBM_sofar;


### PR DESCRIPTION
The logic of `cdd_equiv` remains unchanged.