### PR TITLE
Add two more extraction methods

### DIFF
--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -604,8 +604,6 @@ extern ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t dim);
  */
 extern ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t dim);
 
-
-
 /**
  * Print a CDD \a r as a dot input file \a ofile.\n\n
  *
@@ -1068,18 +1066,13 @@ inline cdd cdd_reduce2(const cdd& r) { return cdd(cdd_reduce2(r.root)); }
  */
 inline cdd cdd_extract_dbm(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(cdd_extract_dbm(r.root, dbm, dim)); }
 
-
-
 /**
  * Extract the bottom BDD of the first DBM in a given CDD
  * @param cdd a cdd
  * @param dbm a dbm
  * @return the difference between \a cdd and \a dbm
  */
-inline cdd cdd_extract_bdd(const cdd& r, raw_t* dbm, int32_t dim)
-{
-    return cdd(cdd_extract_bdd(r.root, dbm, dim));
-}
+inline cdd cdd_extract_bdd(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(cdd_extract_bdd(r.root, dbm, dim)); }
 
 /**
  * Print a CDD \a r as a dot input file \a ofile. You can use the dot

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -895,9 +895,9 @@ private:
 /** Structure for returning the results of extractDBM */
 typedef struct extraction_result
 {
-    cdd* CDD_part; /**< The remainder of the CDD after removing a DBM */
-    cdd* BDD_part; /**< The boolean part below a removed DBM */
-    raw_t* dbm;    /**< the removed DBM */
+    cdd CDD_part; /**< The remainder of the CDD after removing a DBM */
+    cdd BDD_part; /**< The boolean part below a removed DBM */
+    raw_t* dbm;   /**< The removed DBM */
 } extraction_result;
 
 /**

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -1062,14 +1062,16 @@ inline cdd cdd_reduce2(const cdd& r) { return cdd(cdd_reduce2(r.root)); }
  * \a cdd \ \c cdd_from_dbm(dbm).
  * @param cdd a cdd
  * @param dbm a dbm
+ * @param dim the dimension of the dbm
  * @return the difference between \a cdd and \a dbm
  */
 inline cdd cdd_extract_dbm(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(cdd_extract_dbm(r.root, dbm, dim)); }
 
 /**
- * Extract the bottom BDD of the first DBM in a given CDD
+ * Extract the bottom BDD of the first DBM in a given CDD.
  * @param cdd a cdd
  * @param dbm a dbm
+ * @param dim the dimension of the dbm
  * @return the difference between \a cdd and \a dbm
  */
 inline cdd cdd_extract_bdd(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(cdd_extract_bdd(r.root, dbm, dim)); }

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -742,6 +742,8 @@ extern ddNode* cddtrue;
  * @{
  */
 
+struct extraction_result;
+
 /**
  * C++ encapsulation of a decision diagram node (a ddNode). The class
  * maintains a reference to the node throughout its lifetime.
@@ -875,6 +877,7 @@ private:
     friend bool cdd_contains(const cdd&, raw_t* dbm, int32_t dim);
     friend cdd cdd_extract_dbm(const cdd&, raw_t* dbm, int32_t dim);
     friend cdd cdd_extract_bdd(const cdd&, raw_t* dbm, int32_t dim);
+    friend extraction_result cdd_extract_bdd_and_dbm(const cdd&);
     friend void cdd_fprintdot(FILE* ofile, const cdd&, bool push_negate);
     friend void cdd_printdot(const cdd&, bool push_negate);
     friend void cdd_fprint_code(FILE* ofile, const cdd&, cdd_print_varloc_f printer1, cdd_print_clockdiff_f printer2,
@@ -890,6 +893,14 @@ private:
 };
 
 /*=== Inline C++ interface ============================================*/
+
+/** Structure for returning the results of extractDBM */
+typedef struct extraction_result
+{
+    cdd* CDD_part; /**< The remainder of the CDD after removing a DBM */
+    cdd* BDD_part; /**< The boolean part below a removed DBM */
+    raw_t* dbm;    /**< the removed DBM */
+} extraction_result;
 
 /**
  * Returns true if \a dbm is included in the CDD.

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -586,11 +586,25 @@ extern ddNode* cdd_from_dbm(const raw_t* dbm, int32_t dim);
  * Extract a zone from a CDD.  This function will extract a zone from
  * \a cdd and write it to \a dbm.  It will return a CDD equivalent to
  * \a cdd \ \c cdd_from_dbm(dbm).
+ * PRECONDITION: call CDD reduce first!!!
  * @param cdd a cdd
  * @param dbm a dbm
  * @return the difference between \a cdd and \a dbm
  */
 extern ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t dim);
+
+/**
+ * Extract a BDD from the botten of a given CDD
+ * \a cdd and write it to \a dbm.  It will return a CDD equivalent to
+ * \a cdd \ \c cdd_from_dbm(dbm).
+ * PRECONDITION: call CDD reduce first!!!
+ * @param cdd a cdd
+ * @param dbm a dbm
+ * @return the difference between \a cdd and \a dbm
+ */
+extern ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t dim);
+
+
 
 /**
  * Print a CDD \a r as a dot input file \a ofile.\n\n
@@ -860,6 +874,7 @@ private:
     friend cdd cdd_reduce2(const cdd&);
     friend bool cdd_contains(const cdd&, raw_t* dbm, int32_t dim);
     friend cdd cdd_extract_dbm(const cdd&, raw_t* dbm, int32_t dim);
+    friend cdd cdd_extract_bdd(const cdd&, raw_t* dbm, int32_t dim);
     friend void cdd_fprintdot(FILE* ofile, const cdd&, bool push_negate);
     friend void cdd_printdot(const cdd&, bool push_negate);
     friend void cdd_fprint_code(FILE* ofile, const cdd&, cdd_print_varloc_f printer1, cdd_print_clockdiff_f printer2,
@@ -1041,6 +1056,19 @@ inline cdd cdd_reduce2(const cdd& r) { return cdd(cdd_reduce2(r.root)); }
  * @return the difference between \a cdd and \a dbm
  */
 inline cdd cdd_extract_dbm(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(cdd_extract_dbm(r.root, dbm, dim)); }
+
+
+
+/**
+ * Extract the bottom BDD of the first DBM in a given CDD
+ * @param cdd a cdd
+ * @param dbm a dbm
+ * @return the difference between \a cdd and \a dbm
+ */
+inline cdd cdd_extract_bdd(const cdd& r, raw_t* dbm, int32_t dim)
+{
+    return cdd(cdd_extract_bdd(r.root, dbm, dim));
+}
 
 /**
  * Print a CDD \a r as a dot input file \a ofile. You can use the dot

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -594,15 +594,13 @@ extern ddNode* cdd_from_dbm(const raw_t* dbm, int32_t dim);
 extern ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t dim);
 
 /**
- * Extract a BDD from the botten of a given CDD
- * \a cdd and write it to \a dbm.  It will return a CDD equivalent to
- * \a cdd \ \c cdd_from_dbm(dbm).
+ * Extract a BDD from the bottom of a given CDD.
  * PRECONDITION: call CDD reduce first!!!
  * @param cdd a cdd
  * @param dbm a dbm
  * @return the difference between \a cdd and \a dbm
  */
-extern ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t dim);
+extern ddNode* cdd_extract_bdd(ddNode* cdd, int32_t dim);
 
 /**
  * Print a CDD \a r as a dot input file \a ofile.\n\n
@@ -874,7 +872,7 @@ private:
     friend cdd cdd_reduce2(const cdd&);
     friend bool cdd_contains(const cdd&, raw_t* dbm, int32_t dim);
     friend cdd cdd_extract_dbm(const cdd&, raw_t* dbm, int32_t dim);
-    friend cdd cdd_extract_bdd(const cdd&, raw_t* dbm, int32_t dim);
+    friend cdd cdd_extract_bdd(const cdd&, int32_t dim);
     friend extraction_result cdd_extract_bdd_and_dbm(const cdd&);
     friend void cdd_fprintdot(FILE* ofile, const cdd&, bool push_negate);
     friend void cdd_printdot(const cdd&, bool push_negate);
@@ -1070,11 +1068,10 @@ inline cdd cdd_extract_dbm(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(c
 /**
  * Extract the bottom BDD of the first DBM in a given CDD.
  * @param cdd a cdd
- * @param dbm a dbm
  * @param dim the dimension of the dbm
  * @return the difference between \a cdd and \a dbm
  */
-inline cdd cdd_extract_bdd(const cdd& r, raw_t* dbm, int32_t dim) { return cdd(cdd_extract_bdd(r.root, dbm, dim)); }
+inline cdd cdd_extract_bdd(const cdd& r, int32_t dim) { return cdd(cdd_extract_bdd(r.root, dim)); }
 
 /**
  * Print a CDD \a r as a dot input file \a ofile. You can use the dot

--- a/include/cdd/kernel.h
+++ b/include/cdd/kernel.h
@@ -418,9 +418,10 @@ extern int32_t* cdd_diff2level;
 extern Elem* cdd_refstack;
 extern Elem* cdd_refstacktop;  ///< Reference stack
 extern size_t cdd_refstacksize;
-extern int32_t cdd_clocknum;  ///< Number of clocks
-extern int32_t cdd_varnum;    ///< Number of BDD variables
-extern int32_t cdd_levelcnt;  ///< Number of levels
+extern int32_t bdd_start_level;  ///< BDD start level
+extern int32_t cdd_clocknum;     ///< Number of clocks
+extern int32_t cdd_varnum;       ///< Number of BDD variables
+extern int32_t cdd_levelcnt;     ///< Number of levels
 extern LevelInfo* cdd_levelinfo;
 
 #define cdd_push(node, bound)            \

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -1161,7 +1161,7 @@ ddNode* cdd_extract_bdd(ddNode* cdd, int32_t size)
 {
     cdd_iterator it;
     LevelInfo* info;
-    ddNode *node;
+    ddNode* node;
 
     node = cdd;
 

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -1161,12 +1161,9 @@ ddNode* cdd_extract_bdd(ddNode* cdd, int32_t size)
 {
     cdd_iterator it;
     LevelInfo* info;
-    ddNode *node, *zone, *result;
-    uint32_t touched[bits2intsize(size)];
+    ddNode *node;
 
     node = cdd;
-
-    base_resetBits(touched, bits2intsize(size));
 
     while (!(cdd_isterminal(node))) {
         info = cdd_info(node);

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -1114,12 +1114,9 @@ ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t size)
     ddNode *node, *zone, *result;
     uint32_t touched[bits2intsize(size)];
 
-    // cdd_printdot(cdd);
-
     node = cdd;
 
     dbm_init(dbm, size);
-    // dbm_print(stdout, dbm, size);
 
     base_resetBits(touched, bits2intsize(size));
 
@@ -1141,10 +1138,6 @@ ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t size)
 
         assert(cdd_it_child(it) != cddfalse);
 
-        /*printf("%d %d %d %d\n",
-               info->clock1, info->clock2,
-               bnd_l2u(cdd_it_lower(it)), cdd_it_upper(it));*/
-
         dbm_constrain(dbm, size, info->clock2, info->clock1, bnd_l2u(cdd_it_lower(it)), touched);
 
         dbm_constrain(dbm, size, info->clock1, info->clock2, cdd_it_upper(it), touched);
@@ -1164,25 +1157,23 @@ ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t size)
     return result;
 }
 
-
-
-ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t size) {
+ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t size)
+{
     cdd_iterator it;
-    LevelInfo *info;
+    LevelInfo* info;
     ddNode *node, *zone, *result;
     uint32_t touched[bits2intsize(size)];
 
     node = cdd;
 
     dbm_init(dbm, size);
-    // dbm_print(stdout, dbm, size);
 
     base_resetBits(touched, bits2intsize(size));
 
     while (!(cdd_isterminal(node))) {
         info = cdd_info(node);
         if (info->type == TYPE_BDD) {
-           return (node);
+            return (node);
         }
         assert(info->type != TYPE_BDD);
 
@@ -1196,23 +1187,11 @@ ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t size) {
 
         assert(cdd_it_child(it) != cddfalse);
 
-        if (info->type != TYPE_BDD) {
-           // dbm_constrain(dbm, size, info->clock2, info->clock1, bnd_l2u(cdd_it_lower(it)), touched);
-
-           // dbm_constrain(dbm, size, info->clock1, info->clock2, cdd_it_upper(it), touched);
-        }
         node = cdd_it_child(it);
     }
 
     return cddtrue;
 }
-
-
-
-
-
-
-
 
 void cdd_mark_clock(int32_t* vec, int32_t c)
 {

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -1157,7 +1157,7 @@ ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t size)
     return result;
 }
 
-ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t size)
+ddNode* cdd_extract_bdd(ddNode* cdd, int32_t size)
 {
     cdd_iterator it;
     LevelInfo* info;
@@ -1165,8 +1165,6 @@ ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t size)
     uint32_t touched[bits2intsize(size)];
 
     node = cdd;
-
-    dbm_init(dbm, size);
 
     base_resetBits(touched, bits2intsize(size));
 

--- a/src/cddop.c
+++ b/src/cddop.c
@@ -406,9 +406,9 @@ static int32_t cdd_contains_rec(ddNode* node, raw_t* d, int32_t dim)
         free(tmp);
         break;
     case TYPE_BDD:
-        if (!cdd_contains_rec(bdd_node(node)->low, d, dim))
-            return 0;
-        if (!cdd_contains_rec(bdd_node(node)->high, d, dim))
+        if (cdd_contains_rec(bdd_node(node)->low, d, dim) | cdd_contains_rec(bdd_node(node)->high, d, dim))
+            return 1;
+        else
             return 0;
         break;
     }
@@ -1126,6 +1126,11 @@ ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t size)
     while (!cdd_isterminal(node)) {
         info = cdd_info(node);
 
+        if (info->type == TYPE_BDD) {
+            break;
+        }
+        assert(info->type != TYPE_BDD);
+
         assert(info->clock1 < size);
         assert(info->clock2 < size);
 
@@ -1158,6 +1163,56 @@ ddNode* cdd_extract_dbm(ddNode* cdd, raw_t* dbm, int32_t size)
 
     return result;
 }
+
+
+
+ddNode* cdd_extract_bdd(ddNode* cdd, raw_t* dbm, int32_t size) {
+    cdd_iterator it;
+    LevelInfo *info;
+    ddNode *node, *zone, *result;
+    uint32_t touched[bits2intsize(size)];
+
+    node = cdd;
+
+    dbm_init(dbm, size);
+    // dbm_print(stdout, dbm, size);
+
+    base_resetBits(touched, bits2intsize(size));
+
+    while (!(cdd_isterminal(node))) {
+        info = cdd_info(node);
+        if (info->type == TYPE_BDD) {
+           return (node);
+        }
+        assert(info->type != TYPE_BDD);
+
+        assert(info->clock1 < size);
+        assert(info->clock2 < size);
+
+        cdd_it_init(it, node);
+        if (IS_FALSE(cdd_it_child(it))) {
+            cdd_it_next(it);
+        }
+
+        assert(cdd_it_child(it) != cddfalse);
+
+        if (info->type != TYPE_BDD) {
+           // dbm_constrain(dbm, size, info->clock2, info->clock1, bnd_l2u(cdd_it_lower(it)), touched);
+
+           // dbm_constrain(dbm, size, info->clock1, info->clock2, cdd_it_upper(it), touched);
+        }
+        node = cdd_it_child(it);
+    }
+
+    return cddtrue;
+}
+
+
+
+
+
+
+
 
 void cdd_mark_clock(int32_t* vec, int32_t c)
 {

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -54,3 +54,16 @@ cdd cdd::operator=(ddNode* node)
     }
     return *this;
 }
+
+extraction_result cdd_extract_bdd_and_dbm(const cdd& state)
+{
+    uint32_t size = cdd_clocknum;
+    ADBM(dbm);
+    cdd bdd_part = cdd_extract_bdd(state, dbm, size);
+    cdd cdd_part = cdd_extract_dbm(state, dbm, size);
+    extraction_result res;
+    res.BDD_part = bdd_part;
+    res.CDD_part = cdd_part;
+    res.dbm = dbm;
+    return res;
+}

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -64,7 +64,7 @@ extraction_result cdd_extract_bdd_and_dbm(const cdd& state)
 {
     uint32_t size = cdd_clocknum;
     ADBM(dbm);
-    cdd bdd_part = cdd_extract_bdd(state, dbm, size);
+    cdd bdd_part = cdd_extract_bdd(state, size);
     cdd cdd_part = cdd_extract_dbm(state, dbm, size);
     extraction_result res;
     res.BDD_part = bdd_part;

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -11,6 +11,11 @@
 
 #include "cdd/kernel.h"
 
+#define ADBM(NAME) raw_t* NAME = allocDBM(size)
+
+/* Allocate a DBM. */
+static raw_t* allocDBM(uint32_t dim) { return (raw_t*)malloc(dim * dim * sizeof(raw_t)); }
+
 cdd::cdd(const cdd& r)
 {
     assert(cdd_isrunning());

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -60,6 +60,13 @@ cdd cdd::operator=(ddNode* node)
     return *this;
 }
 
+/**
+ * Extract a BDD and DBM from a given CDD.
+ * PRECONDITION: call CDD reduce first!!!
+ * @param cdd a cdd
+ * @return the extraction result containing the extracted BDD,
+ *      extracted DBM ,and the remaining cdd.
+ */
 extraction_result cdd_extract_bdd_and_dbm(const cdd& state)
 {
     uint32_t size = cdd_clocknum;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -79,6 +79,7 @@ int32_t cdd_rehashcnt;    /**< Number of times we have rehashed. */
 int32_t cdd_maxcddsize;   /**< Max. arity of a node. */
 int32_t cdd_maxcddused;   /**< Max. nodes the library may allocate. */
 int32_t cdd_chunkcnt;     /**< Total number of chunks allocated. */
+int32_t bdd_start_level;  /**< BDD start level */
 int32_t cdd_clocknum;     /**< Number of clocks allocated. */
 int32_t cdd_varnum;       /**< Number of BDD variables allocated. */
 LevelInfo* cdd_levelinfo;
@@ -1084,6 +1085,7 @@ int32_t cdd_add_bddvar(int32_t n)
         info++;
         n--;
     }
+    bdd_start_level = offset;
     return offset;
 }
 

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -113,7 +113,7 @@ static void test_extract_bdd(size_t size)
     cdd3 = cdd1 & cdd2;
 
     // Extract the DBM and BDD part:
-    cdd4 = cdd_extract_bdd(cdd3, dbm2.raw(), size);
+    cdd4 = cdd_extract_bdd(cdd3, size);
 
     // Check the result:
     REQUIRE(cdd_equiv(cdd4, cdd2));

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -100,6 +100,25 @@ static void test_conversion(size_t size)
     REQUIRE(cdd_reduce(cdd2) == cdd_false());
 }
 
+static void test_extract_bdd(size_t size)
+{
+    cdd cdd1, cdd2, cdd3, cdd4;
+    auto dbm1 = dbm_wrap{size};
+    auto dbm2 = dbm_wrap{size};
+
+    // Create DBM and CDDs:
+    dbm1.generate();
+    cdd1 = cdd{dbm1.raw(), dbm1.size()};
+    cdd2 = cdd_bddvarpp(bdd_start_level + size - 1);
+    cdd3 = cdd1 & cdd2;
+
+    // Extract the DBM and BDD part:
+    cdd4 = cdd_extract_bdd(cdd3, dbm2.raw(), size);
+
+    // Check the result:
+    REQUIRE(cdd_equiv(cdd4, cdd2));
+}
+
 /* test intersection of CDDs
  */
 static void test_intersection(size_t size)
@@ -294,6 +313,7 @@ void big_test(uint32_t n, uint32_t seed)
 {
     cdd_init(100000, 10000, 10000);
     cdd_add_clocks(n);
+    cdd_add_bddvar(n);
 
     for (uint32_t j = 1; j <= 10; ++j) {
         uint32_t DBM_sofar = dbm_wrap::get_allDBMs();
@@ -307,6 +327,7 @@ void big_test(uint32_t n, uint32_t seed)
             test("test_apply_reduce", test_apply_reduce, i);
             test("test_reduce      ", test_reduce, i);
             test("test_equiv       ", test_equiv, i);
+            test("test_extract_bdd ", test_extract_bdd, i);
         }
         test("test_remove_negative", test_remove_negative, n);
         passDBMs = dbm_wrap::get_allDBMs() - DBM_sofar;


### PR DESCRIPTION
This merge request adds
- `cdd_extract_bdd`
- `cdd_extract_bdd_and_dbm`

The original code only contained `cdd_extract_dbm`, which is on itself insufficient when a cdd contains both clock difference and BDD nodes.

Also a small correction was added in `cdd_contains`.