### PR TITLE
Add cdd-bdd_to_array function

### DIFF
--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -871,7 +871,7 @@ private:
     friend bool cdd_equiv(const cdd&, const cdd&);
     friend cdd cdd_delay(const cdd&);
     friend cdd cdd_past(const cdd&);
-    friend bdd_arrays cdd_bdd_to_array(const cdd&, int32_t);
+    friend bdd_arrays cdd_bdd_to_array(const cdd&);
     friend cdd cdd_delay_invariant(const cdd&, const cdd&);
     friend cdd cdd_apply_reset(const cdd& state, int32_t* clock_resets, int32_t* clock_values, int32_t num_clock_resets,
                                int32_t* bool_resets, int32_t* bool_values, int32_t num_bool_resets);

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -912,13 +912,13 @@ typedef struct extraction_result
     raw_t* dbm;   /**< The removed DBM */
 } extraction_result;
 
-/** Structure for returning the logical formula of a BDD */
+/** Structure for returning the logical formula of a BDD. */
 typedef struct bdd_arrays
 {
-    int32_t* vars;   /** the variables that are relevant */
-    int32_t* values; /** the value the variables have */
-    int32_t numTraces;
-    int32_t numBools;
+    int32_t* vars;     /** The variables that are relevant. Size = numTraces x numBools. */
+    int32_t* values;   /** The value the variables have. Size = numTraces x numBools. */
+    int32_t numTraces; /** The number of traces collected. */
+    int32_t numBools;  /** The number of maximum boolean variables per trace.*/
 } bdd_arrays;
 
 /**

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -739,7 +739,7 @@ extern ddNode* cddtrue;
  */
 
 struct extraction_result;
-
+struct bdd_arrays;
 /**
  * C++ encapsulation of a decision diagram node (a ddNode). The class
  * maintains a reference to the node throughout its lifetime.
@@ -871,7 +871,7 @@ private:
     friend bool cdd_equiv(const cdd&, const cdd&);
     friend cdd cdd_delay(const cdd&);
     friend cdd cdd_past(const cdd&);
-    friend void cdd_bdd_to_array(const cdd&, int32_t );
+    friend bdd_arrays cdd_bdd_to_array(const cdd&, int32_t );
     friend cdd cdd_delay_invariant(const cdd&, const cdd&);
     friend cdd cdd_apply_reset(const cdd& state, int32_t* clock_resets, int32_t* clock_values, int32_t num_clock_resets,
                                int32_t* bool_resets, int32_t* bool_values, int32_t num_bool_resets);
@@ -911,6 +911,16 @@ typedef struct extraction_result
     cdd BDD_part; /**< The boolean part below a removed DBM */
     raw_t* dbm;   /**< The removed DBM */
 } extraction_result;
+
+
+/** Structure for returning the logical forumal of a BDD */
+typedef struct bdd_arrays
+{
+    int32_t* vars;      /** the variables that are relevant */
+    int32_t* values;   /** the value the variables have */
+    int32_t numTraces;
+    int32_t numBools;
+} bdd_arrays;
 
 /**
  * Returns true if \a dbm is included in the CDD.

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -871,6 +871,7 @@ private:
     friend bool cdd_equiv(const cdd&, const cdd&);
     friend cdd cdd_delay(const cdd&);
     friend cdd cdd_past(const cdd&);
+    friend void cdd_bdd_to_array(const cdd&, int32_t );
     friend cdd cdd_delay_invariant(const cdd&, const cdd&);
     friend cdd cdd_apply_reset(const cdd& state, int32_t* clock_resets, int32_t* clock_values, int32_t num_clock_resets,
                                int32_t* bool_resets, int32_t* bool_values, int32_t num_bool_resets);

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -871,7 +871,7 @@ private:
     friend bool cdd_equiv(const cdd&, const cdd&);
     friend cdd cdd_delay(const cdd&);
     friend cdd cdd_past(const cdd&);
-    friend bdd_arrays cdd_bdd_to_array(const cdd&, int32_t );
+    friend bdd_arrays cdd_bdd_to_array(const cdd&, int32_t);
     friend cdd cdd_delay_invariant(const cdd&, const cdd&);
     friend cdd cdd_apply_reset(const cdd& state, int32_t* clock_resets, int32_t* clock_values, int32_t num_clock_resets,
                                int32_t* bool_resets, int32_t* bool_values, int32_t num_bool_resets);
@@ -912,12 +912,11 @@ typedef struct extraction_result
     raw_t* dbm;   /**< The removed DBM */
 } extraction_result;
 
-
 /** Structure for returning the logical formula of a BDD */
 typedef struct bdd_arrays
 {
-    int32_t* vars;      /** the variables that are relevant */
-    int32_t* values;   /** the value the variables have */
+    int32_t* vars;   /** the variables that are relevant */
+    int32_t* values; /** the value the variables have */
     int32_t numTraces;
     int32_t numBools;
 } bdd_arrays;

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -913,7 +913,7 @@ typedef struct extraction_result
 } extraction_result;
 
 
-/** Structure for returning the logical forumal of a BDD */
+/** Structure for returning the logical formula of a BDD */
 typedef struct bdd_arrays
 {
     int32_t* vars;      /** the variables that are relevant */

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -361,14 +361,9 @@ public:
     void delete_ignored_rows()
     {
         int i = 0;
-        for (auto it = matrix.begin(); it != matrix.end();) {
-            if (rows_to_be_ignored.at(i)) {
-                matrix.erase(it);
-            } else {
-                ++it;
-            }
-            ++i;
-        }
+        matrix.erase(std::remove_if(matrix.begin(), matrix.end(),
+                                    [&i, this](const auto& value) { return rows_to_be_ignored.at(i++); }),
+                     matrix.end());
     }
 
     /**

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -561,23 +561,23 @@ bdd_arrays cdd_bdd_to_array(const cdd& state)
     auto init_num_of_traces = std::min(1u << cdd_varnum, 100u);  // 1u<<cdd_varnum <==> 2 ^ cdd_varnum
     int32_t initial_value = -1;
 
-    auto* varsMatrix = new dynamic_two_dim_matrix(init_num_of_traces, cdd_varnum, initial_value);
-    auto* valuesMatrix = new dynamic_two_dim_matrix(init_num_of_traces, cdd_varnum, initial_value);
+    auto varsMatrix = dynamic_two_dim_matrix(init_num_of_traces, cdd_varnum, initial_value);
+    auto valuesMatrix = dynamic_two_dim_matrix(init_num_of_traces, cdd_varnum, initial_value);
 
     // Perform the actual depth-first search.
-    cdd_bdd_to_matrix_rec(state.handle(), varsMatrix, valuesMatrix, 0, false);
+    cdd_bdd_to_matrix_rec(state.handle(), &varsMatrix, &valuesMatrix, 0, false);
 
     // Delete ignored rows from the result.
-    assert(varsMatrix->get_current_row() == valuesMatrix->get_current_row());
-    varsMatrix->delete_ignored_rows();
-    valuesMatrix->delete_ignored_rows();
-    assert(varsMatrix->get_current_row() == valuesMatrix->get_current_row());
+    assert(varsMatrix.get_current_row() == valuesMatrix.get_current_row());
+    varsMatrix.delete_ignored_rows();
+    valuesMatrix.delete_ignored_rows();
+    assert(varsMatrix.get_current_row() == valuesMatrix.get_current_row());
 
     bdd_arrays arrays;
-    arrays.vars = varsMatrix->get_array();
-    arrays.values = valuesMatrix->get_array();
+    arrays.vars = varsMatrix.get_array();
+    arrays.values = valuesMatrix.get_array();
     arrays.numBools = cdd_varnum;
-    arrays.numTraces = varsMatrix->get_current_row() + 1;
+    arrays.numTraces = varsMatrix.get_current_row() + 1;
 
     // Check for the special case when no trace was effectively generated (or all traces ended in
     // the false terminal)
@@ -585,10 +585,8 @@ bdd_arrays cdd_bdd_to_array(const cdd& state)
         arrays.numTraces = 0;
     }
 
-    varsMatrix->clean();
-    valuesMatrix->clean();
-    delete varsMatrix;
-    delete valuesMatrix;
+    varsMatrix.clean();
+    valuesMatrix.clean();
     return arrays;
 }
 

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -415,14 +415,14 @@ bdd_arrays cdd_bdd_to_array(const cdd& state, int num_bools)
 
     bdd_arrays arys;
 
-    int32_t *varRes = new int32_t[num_bools*currentTrace];
-    int32_t *valRes = new int32_t[num_bools*currentTrace];
+    int32_t *varRes = new int32_t[(num_bools-1)*(currentTrace-1)];
+    int32_t *valRes = new int32_t[(num_bools-1)*(currentTrace-1)];
     for (uint32_t  i = 0; i< currentTrace; i++)
     {
         for (uint32_t  j= 0; j<num_bools;j++)
         {
             varRes[i*num_bools+j]= resultArraysVars[i][j];
-            valRes[i*num_bools+j]= resultArraysVars[i][j];
+            valRes[i*num_bools+j]= resultArraysValues[i][j];
         }
     }
 
@@ -431,7 +431,7 @@ bdd_arrays cdd_bdd_to_array(const cdd& state, int num_bools)
     arys.numTraces=currentTrace;
     arys.numBools=num_bools;
 
-    for(int i = 0; i < currentTrace-1; ++i) {
+    for(int i = 0; i < currentTrace; ++i) {
         delete [] resultArraysVars[i];
         delete [] resultArraysValues[i];
     }

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -553,9 +553,6 @@ void cdd_bdd_to_matrix_rec(ddNode* r, dynamic_two_dim_matrix* varsMatrix, dynami
 /**
  * Transform a BDD into an array representation.
  *
- * TODO some explanation about the structure of the array.
- * <p></p>
- *
  * @param state a cdd containing only BDD or terminal nodes
  * @return an array representation of the BDD.
  */

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -375,7 +375,7 @@ public:
     void delete_ignored_rows()
     {
         int i = 0;
-        for (auto it = matrix.begin(); it != matrix.end(); ) {
+        for (auto it = matrix.begin(); it != matrix.end();) {
             if (rows_to_be_ignored.at(i)) {
                 matrix.erase(it);
             } else {
@@ -399,7 +399,7 @@ public:
             for (; j < matrix.at(i).size(); j++) {
                 array[i * num_cols + j] = matrix.at(i).at(j);
             }
-            for(; j < num_cols; j++) {
+            for (; j < num_cols; j++) {
                 array[i * num_cols + j] = default_value;
             }
         }
@@ -417,7 +417,6 @@ private:
     std::vector<std::vector<int32_t>> matrix;
     std::vector<bool> rows_to_be_ignored;
     int num_cols;
-
 };
 
 /**

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -313,8 +313,7 @@ cdd cdd_past(const cdd& state)
     return res;
 }
 
-int arraySize=10;
-int maxNumberOfArrays=10;
+int maxNumberOfTraces =10;
 int** resultArraysVars;// = new int[arraySize];
 int** resultArraysValues;// = new int[arraySize];
 int currentTrace;
@@ -322,9 +321,9 @@ int currentTrace;
 void resizeArrays()
 {
     printf("resizing");
-    int ** newVarsArray = new int*[maxNumberOfArrays*2];
-    int ** newValuesArray = new int*[maxNumberOfArrays*2];
-    for (int i=0; i<maxNumberOfArrays;i++) {
+    int ** newVarsArray = new int*[maxNumberOfTraces *2];
+    int ** newValuesArray = new int*[maxNumberOfTraces *2];
+    for (int i=0; i< maxNumberOfTraces;i++) {
         newValuesArray[i] = resultArraysValues[i];
         newVarsArray[i] = resultArraysVars[i];
     }
@@ -334,7 +333,7 @@ void resizeArrays()
     }
     delete[] resultArraysVars;
     delete[] resultArraysValues;
-    maxNumberOfArrays=maxNumberOfArrays*2;
+    maxNumberOfTraces = maxNumberOfTraces *2;
     resultArraysVars = newVarsArray;
     resultArraysValues = newValuesArray;
 }
@@ -344,12 +343,12 @@ void resizeArrays()
 void cdd_bdd_to_array_rec(ddNode* r, int32_t* trace_vars,  int32_t* trace_values, int32_t  current_step, bool negated, int num_bools)
 {
     if (r == cddtrue && negated ==false) {
-        if (currentTrace==maxNumberOfArrays-1)
+        if (currentTrace== maxNumberOfTraces -1)
             resizeArrays();
-        resultArraysValues[currentTrace]=new int[num_bools-1];
-        resultArraysVars[currentTrace]=new int[num_bools-1];
+        resultArraysValues[currentTrace]=new int[num_bools];
+        resultArraysVars[currentTrace]=new int[num_bools];
         int i;
-        for (i = 0; i <= (sizeof(trace_vars) / sizeof(trace_vars[0])); i++) {
+        for (i = 0; i < num_bools; i++) {
             resultArraysValues[currentTrace][i]=trace_values[i];
             resultArraysVars[currentTrace][i]=trace_vars[i];
         }
@@ -362,12 +361,12 @@ void cdd_bdd_to_array_rec(ddNode* r, int32_t* trace_vars,  int32_t* trace_values
     if (r == cddfalse && negated ==true)
     {
 
-            if (currentTrace==maxNumberOfArrays-1)
+            if (currentTrace== maxNumberOfTraces -1)
                 resizeArrays();
-            resultArraysValues[currentTrace]=new int[num_bools-1];
-            resultArraysVars[currentTrace]=new int[num_bools-1];
+            resultArraysValues[currentTrace]=new int[num_bools];
+            resultArraysVars[currentTrace]=new int[num_bools];
             int i;
-            for (i = 0; i <= (sizeof(trace_vars) / sizeof(trace_vars[0])); i++) {
+            for (i = 0; i < num_bools; i++) {
                 resultArraysValues[currentTrace][i]=trace_values[i];
                 resultArraysVars[currentTrace][i]=trace_vars[i];
             }
@@ -411,9 +410,9 @@ void cdd_bdd_to_array_rec(ddNode* r, int32_t* trace_vars,  int32_t* trace_values
 bdd_arrays cdd_bdd_to_array(const cdd& state, int num_bools)
 {
     currentTrace=0;
-    maxNumberOfArrays=100;
-    resultArraysVars=new int*[maxNumberOfArrays];
-    resultArraysValues=new int*[maxNumberOfArrays];
+    maxNumberOfTraces =100;
+    resultArraysVars=new int*[maxNumberOfTraces];
+    resultArraysValues=new int*[maxNumberOfTraces];
 
     int vars[num_bools];
     int values[num_bools];
@@ -421,17 +420,18 @@ bdd_arrays cdd_bdd_to_array(const cdd& state, int num_bools)
         vars[i]=-1;
         values[i]=-1;
     }
-
     cdd_bdd_to_array_rec(state.handle(),vars,values, 0,false, num_bools);
+    printf("allocating now %i \n" ,(num_bools)*(currentTrace));
 
-    int32_t *varRes = new int32_t[(num_bools-1)*(currentTrace-1)];
-    int32_t *valRes = new int32_t[(num_bools-1)*(currentTrace-1)];
+
+    int32_t *varRes = new int32_t[(num_bools)*(currentTrace)];
+    int32_t *valRes = new int32_t[(num_bools)*(currentTrace)];
     for (uint32_t  i = 0; i< currentTrace; i++)
     {
         for (uint32_t  j= 0; j<num_bools;j++)
         {
-            varRes[i*(num_bools-1)+j]= resultArraysVars[i][j];
-            valRes[i*(num_bools-1)+j]= resultArraysValues[i][j];
+            varRes[i*(num_bools)+j]= resultArraysVars[i][j];
+            valRes[i*(num_bools)+j]= resultArraysValues[i][j];
         }
     }
 

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -1004,7 +1004,8 @@ TEST_CASE("CDD BDD to array test")
         int32_t expected_vars1[8] = {bdd_start_level, default_value,       default_value,       default_value,
                                      bdd_start_level, bdd_start_level + 1, bdd_start_level + 2, default_value};
         REQUIRE(equal(array1.vars, expected_vars1, 8));
-        int32_t expected_values1[8] = {1, default_value, default_value, default_value, 0, 1, 1, default_value};
+        int32_t expected_values1[8] = {1, default_value, default_value, default_value,
+                                       0, 1, 1, default_value};
         REQUIRE(equal(array1.values, expected_values1, 8));
 
         delete[] array1.vars;
@@ -1033,7 +1034,8 @@ TEST_CASE("CDD BDD to array test")
         int32_t expected_vars3[8] = {bdd_start_level, bdd_start_level + 1, bdd_start_level + 2, bdd_start_level + 3,
                                      bdd_start_level, bdd_start_level + 1, bdd_start_level + 3, default_value};
         REQUIRE(equal(array3.vars, expected_vars3, 8));
-        int32_t expected_values3[8] = {1, 0, 0, 0, 0, 1, 0, default_value};
+        int32_t expected_values3[8] = {1, 0, 0, 0,
+                                       0, 1, 0, default_value};
         REQUIRE(equal(array3.values, expected_values3, 8));
 
         delete[] array3.vars;

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -830,19 +830,24 @@ void test_predt(size_t size)
 void test_bdd_to_array(size_t size)
 {
     // First some trivial cases.
-    bdd_arrays result = cdd_bdd_to_array(cdd_true(), cdd_varnum);
+    bdd_arrays result = cdd_bdd_to_array(cdd_true());
     REQUIRE(result.numBools == cdd_varnum);
     REQUIRE(result.numTraces == 0);
+    delete[] result.vars;
+    delete[] result.values;
 
     // Create a random BDD.
     cdd bdd_part = generate_bdd(size);
 
-    bdd_arrays result1 = cdd_bdd_to_array(bdd_part, cdd_varnum);
+    bdd_arrays result1 = cdd_bdd_to_array(bdd_part);
     if (cdd_isterminal(bdd_part.handle())) {
         REQUIRE(result1.numTraces == 0);
     } else {
         REQUIRE(result1.numTraces > 0);
     }
+
+    delete[] result1.vars;
+    delete[] result1.values;
 }
 
 static void test(const char* name, TestFunction f, size_t size)

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -827,6 +827,24 @@ void test_predt(size_t size)
     REQUIRE(cdd_equiv(cdd_predt(test, right), cdd_remove_negative(cdd_past(left))));
 }
 
+void test_bdd_to_array(size_t size)
+{
+    // First some trivial cases.
+    bdd_arrays result = cdd_bdd_to_array(cdd_true(), cdd_varnum);
+    REQUIRE(result.numBools == cdd_varnum);
+    REQUIRE(result.numTraces == 0);
+
+    // Create a random BDD.
+    cdd bdd_part = generate_bdd(size);
+
+    bdd_arrays result1 = cdd_bdd_to_array(bdd_part, cdd_varnum);
+    if (cdd_isterminal(bdd_part.handle())) {
+        REQUIRE(result1.numTraces == 0);
+    } else {
+        REQUIRE(result1.numTraces > 0);
+    }
+}
+
 static void test(const char* name, TestFunction f, size_t size)
 {
     cout << name << " size = " << size << endl;
@@ -865,6 +883,7 @@ static void big_test(uint32_t n)
             test("test_transition_back", test_transition_back, i);
             test("test_transition_back_past", test_transition_back_past, i);
             test("test_predt       ", test_predt, i);
+            test("test_bdd_to_array", test_bdd_to_array, i);
         }
         test("test_remove_negative", test_remove_negative, n);
         passDBMs = dbm_wrap::get_allDBMs() - DBM_sofar;

--- a/test/test_cdd.cpp
+++ b/test/test_cdd.cpp
@@ -1004,8 +1004,7 @@ TEST_CASE("CDD BDD to array test")
         int32_t expected_vars1[8] = {bdd_start_level, default_value,       default_value,       default_value,
                                      bdd_start_level, bdd_start_level + 1, bdd_start_level + 2, default_value};
         REQUIRE(equal(array1.vars, expected_vars1, 8));
-        int32_t expected_values1[8] = {1, default_value, default_value, default_value,
-                                       0, 1, 1, default_value};
+        int32_t expected_values1[8] = {1, default_value, default_value, default_value, 0, 1, 1, default_value};
         REQUIRE(equal(array1.values, expected_values1, 8));
 
         delete[] array1.vars;
@@ -1034,8 +1033,7 @@ TEST_CASE("CDD BDD to array test")
         int32_t expected_vars3[8] = {bdd_start_level, bdd_start_level + 1, bdd_start_level + 2, bdd_start_level + 3,
                                      bdd_start_level, bdd_start_level + 1, bdd_start_level + 3, default_value};
         REQUIRE(equal(array3.vars, expected_vars3, 8));
-        int32_t expected_values3[8] = {1, 0, 0, 0,
-                                       0, 1, 0, default_value};
+        int32_t expected_values3[8] = {1, 0, 0, 0, 0, 1, 0, default_value};
         REQUIRE(equal(array3.values, expected_values3, 8));
 
         delete[] array3.vars;


### PR DESCRIPTION
This pull request adds the `cdd-bdd_to_array` function (including some helper funtions and classes). This function is used to convert a CDD that contains only boolean nodes back into a non-CDD format. (Similar to `cdd_extract_dbm`, which converts part of a CDD into a DBM representation.)

Currently, the boolean CDD is converted into arrays, which is used by J-ECDAR to, for example, display guards in a human-readable format.