### PR TITLE
Added cdd_isBDD & updated doctest version

### DIFF
--- a/getlibs.sh
+++ b/getlibs.sh
@@ -25,9 +25,9 @@ cd "${LIBS_SOURCES}"
 # DOCTEST
 PREFIX="$CMAKE_PREFIX_PATH/doctest"
 if [ ! -d "$PREFIX" ]; then
-    wget -nv -N https://github.com/doctest/doctest/archive/refs/tags/v2.4.8.tar.gz
-    tar -xf v2.4.8.tar.gz
-    SRC_DIR="${LIBS_SOURCES}/doctest-2.4.8"
+    wget -nv -N https://github.com/doctest/doctest/archive/refs/tags/v2.4.9.tar.gz
+    tar -xf v2.4.9.tar.gz
+    SRC_DIR="${LIBS_SOURCES}/doctest-2.4.9"
     BLD_DIR="$SRC_DIR/build"
     cmake $CMAKE_ARGS -DCMAKE_INSTALL_PREFIX="$PREFIX" -DBUILD_SHARED_LIBS=OFF "$SRC_DIR" -B "$BLD_DIR"
     cmake --build "$BLD_DIR" --config Release

--- a/include/cdd/cdd.h
+++ b/include/cdd/cdd.h
@@ -871,6 +871,7 @@ private:
     friend bool cdd_equiv(const cdd&, const cdd&);
     friend cdd cdd_delay(const cdd&);
     friend cdd cdd_past(const cdd&);
+    friend bool cdd_isBDD(const cdd&);
     friend bdd_arrays cdd_bdd_to_array(const cdd&);
     friend cdd cdd_delay_invariant(const cdd&, const cdd&);
     friend cdd cdd_apply_reset(const cdd& state, int32_t* clock_resets, int32_t* clock_values, int32_t num_clock_resets,

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -313,7 +313,7 @@ cdd cdd_past(const cdd& state)
     return res;
 }
 /**
- * Checks if a CDD is a BDD
+ * Checks if a CDD is a BDD.
  * @param state: The CDD to check
  * @return <code>true</code> if the CDD is a BDD and <code>false</code> if it is not
  */

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -312,6 +312,12 @@ cdd cdd_past(const cdd& state)
     free(dbm);
     return res;
 }
+/**
+ * Checks if a CDD is a BDD
+ * @param state: The CDD to check
+ * @return <code>true</code> if the CDD is a BDD and <code>false</code> if it is not
+ */
+bool cdd_isBDD(const cdd& state) { return cdd_isterminal(state.root) || cdd_info(state.handle())->type == TYPE_BDD; }
 
 /**
  * Class for a 2D int32_t matrix where the number of rows is dynamic.

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -315,7 +315,7 @@ cdd cdd_past(const cdd& state)
 /**
  * Checks if a CDD is a BDD.
  * @param state: The CDD to check.
- * @return <code>true</code> if the CDD is a BDD and <code>false</code> if it is not
+ * @return <code>true</code> if the CDD is a BDD and <code>false</code> if it is not.
  */
 bool cdd_isBDD(const cdd& state) { return cdd_isterminal(state.root) || cdd_info(state.handle())->type == TYPE_BDD; }
 

--- a/src/cppext.cpp
+++ b/src/cppext.cpp
@@ -314,7 +314,7 @@ cdd cdd_past(const cdd& state)
 }
 /**
  * Checks if a CDD is a BDD.
- * @param state: The CDD to check
+ * @param state: The CDD to check.
  * @return <code>true</code> if the CDD is a BDD and <code>false</code> if it is not
  */
 bool cdd_isBDD(const cdd& state) { return cdd_isterminal(state.root) || cdd_info(state.handle())->type == TYPE_BDD; }


### PR DESCRIPTION
Added `cdd_isBDD`, and updated `doctest` version from `2.4.8` to `2.4.9` (`2.4.8` used the deprecated `std::sprintf`)